### PR TITLE
Lift to SpeziLLM v0.8, Data race fix

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,9 +28,9 @@ let package = Package(
         .package(url: "https://github.com/StanfordBDHG/HealthKitOnFHIR", .upToNextMinor(from: "0.2.4")),
         .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.2.1"),
         .package(url: "https://github.com/StanfordSpezi/SpeziHealthKit.git", .upToNextMinor(from: "0.5.1")),
-        .package(url: "https://github.com/StanfordSpezi/SpeziLLM.git", .upToNextMinor(from: "0.7.0")),
+        .package(url: "https://github.com/StanfordSpezi/SpeziLLM.git", .upToNextMinor(from: "0.8.1")),
         .package(url: "https://github.com/StanfordSpezi/SpeziStorage.git", from: "1.0.0"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziChat.git", .upToNextMinor(from: "0.1.8")),
+        .package(url: "https://github.com/StanfordSpezi/SpeziChat.git", .upToNextMinor(from: "0.2.0")),
         .package(url: "https://github.com/StanfordSpezi/SpeziSpeech.git", from: "1.0.0")
     ],
     targets: [

--- a/Sources/SpeziFHIRLLM/FHIRInterpretation/MultipleResources/FHIRGetResourceLLMFunction.swift
+++ b/Sources/SpeziFHIRLLM/FHIRInterpretation/MultipleResources/FHIRGetResourceLLMFunction.swift
@@ -43,7 +43,7 @@ struct FHIRGetResourceLLMFunction: LLMFunction {
         
         _resources = Parameter(
             description: String(localized: "PARAMETER_DESCRIPTION"),
-            enumValues: Array(allResourcesFunctionCallIdentifiers)
+            enum: Array(allResourcesFunctionCallIdentifiers)
         )
     }
     

--- a/Sources/SpeziFHIRLLM/FHIRInterpretation/MultipleResources/FHIRMultipleResourceInterpreter.swift
+++ b/Sources/SpeziFHIRLLM/FHIRInterpretation/MultipleResources/FHIRMultipleResourceInterpreter.swift
@@ -18,7 +18,7 @@ import SwiftUI
 
 
 private enum FHIRMultipleResourceInterpreterConstants {
-    static let chat = "FHIRMultipleResourceInterpreter.chat"
+    static let context = "FHIRMultipleResourceInterpreter.context"
 }
 
 
@@ -65,7 +65,7 @@ public class FHIRMultipleResourceInterpreter {
         
         let llm = llmRunner(with: llmSchema)
         // Read initial conversation from storage
-        if let storedContext: Chat = try? localStorage.read(storageKey: FHIRMultipleResourceInterpreterConstants.chat) {
+        if let storedContext: LLMContext = try? localStorage.read(storageKey: FHIRMultipleResourceInterpreterConstants.context) {
             llm.context = storedContext
         } else {
             llm.context.append(systemMessage: FHIRPrompt.interpretMultipleResources.prompt)
@@ -80,7 +80,7 @@ public class FHIRMultipleResourceInterpreter {
     @MainActor
     func queryLLM() {
         guard let llm,
-              llm.context.last?.role == .user || !(llm.context.contains(where: { $0.role == .assistant }) ) else {
+              llm.context.last?.role == .user || !(llm.context.contains(where: { $0.role == .assistant() }) ) else {
             return
         }
         
@@ -96,7 +96,7 @@ public class FHIRMultipleResourceInterpreter {
             }
             
             // Store conversation to storage
-            try localStorage.store(llm.context, storageKey: FHIRMultipleResourceInterpreterConstants.chat)
+            try localStorage.store(llm.context, storageKey: FHIRMultipleResourceInterpreterConstants.context)
         }
     }
     

--- a/Sources/SpeziFHIRLLM/FHIRInterpretation/MultipleResources/MultipleResourcesChatView.swift
+++ b/Sources/SpeziFHIRLLM/FHIRInterpretation/MultipleResources/MultipleResourcesChatView.swift
@@ -28,12 +28,13 @@ public struct MultipleResourcesChatView: View {
         NavigationStack {
             Group {
                 if let llm = multipleResourceInterpreter.llm {
-                    let contextBinding = Binding { llm.context } set: { llm.context = $0 }
+                    let contextBinding = Binding { llm.context.chat } set: { llm.context.chat = $0 }
+                    
                     ChatView(
                         contextBinding,
                         disableInput: llm.state.representation == .processing
                     )
-                        .speak(llm.context, muted: !textToSpeech)
+                        .speak(llm.context.chat, muted: !textToSpeech)
                         .speechToolbarButton(muted: !$textToSpeech)
                         .viewStateAlert(state: llm.state)
                         .onChange(of: llm.context, initial: true) { _, _ in

--- a/Sources/SpeziFHIRLLM/FHIRProcessor/FHIRResourceProcessor.swift
+++ b/Sources/SpeziFHIRLLM/FHIRProcessor/FHIRResourceProcessor.swift
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
+import Foundation
 import SpeziChat
 import SpeziFHIR
 import SpeziLLM
@@ -21,6 +22,7 @@ class FHIRResourceProcessor<Content: Codable & LosslessStringConvertible> {
     private let llmRunner: LLMRunner
     private let storageKey: String
     private let prompt: FHIRPrompt
+    private let lock = NSLock()
     var llmSchema: any LLMSchema
     
     
@@ -66,7 +68,10 @@ class FHIRResourceProcessor<Content: Codable & LosslessStringConvertible> {
             throw FHIRResourceProcessorError.notParsableAsAString
         }
         
-        results[resource.id] = content
+        lock.withLock {
+            results[resource.id] = content
+        }
+        
         return content
     }
 }

--- a/Sources/SpeziFHIRLLM/FHIRProcessor/FHIRResourceProcessor.swift
+++ b/Sources/SpeziFHIRLLM/FHIRProcessor/FHIRResourceProcessor.swift
@@ -61,7 +61,7 @@ class FHIRResourceProcessor<Content: Codable & LosslessStringConvertible> {
         
         let chatStreamResult: String = try await llmRunner.oneShot(
             with: llmSchema,
-            chat: .init(systemMessages: [prompt.prompt(withFHIRResource: resource.jsonDescription)])
+            context: .init(systemMessages: [prompt.prompt(withFHIRResource: resource.jsonDescription)])
         )
         
         guard let content = Content(chatStreamResult) else {


### PR DESCRIPTION
# Lift to SpeziLLM v0.8, Data race fix

## :recycle: Current situation & Problem
As of now, the SpeziFHIRLLM target still uses the outdated SpeziLLM v0.7 version, using old APIs.
Furthermore, a crash of the `FHIRResourceProcessor` could occur in the case of many parallel summarization, e.g., in the `MultipleResourceChatView.`


## :gear: Release Notes 
- Lift to SpeziLLM v0.8
- Fix a data race in the `FHIRResourceProcessor`, ensuring parallel processing capabilities


## :books: Documentation
--


## :white_check_mark: Testing
--


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
