### PR TITLE
Swift 6 language mode readiness and bump dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,14 +31,14 @@ let package = Package(
         .library(name: "SpeziFHIRMockPatients", targets: ["SpeziFHIRMockPatients"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/FHIRModels", .upToNextMinor(from: "0.5.0")),
-        .package(url: "https://github.com/StanfordBDHG/HealthKitOnFHIR", .upToNextMinor(from: "0.2.4")),
-        .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.2.1"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziHealthKit.git", .upToNextMinor(from: "0.5.1")),
-        .package(url: "https://github.com/StanfordSpezi/SpeziLLM.git", .upToNextMinor(from: "0.8.1")),
-        .package(url: "https://github.com/StanfordSpezi/SpeziStorage.git", from: "1.0.0"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziChat.git", .upToNextMinor(from: "0.2.0")),
-        .package(url: "https://github.com/StanfordSpezi/SpeziSpeech.git", from: "1.0.0")
+        .package(url: "https://github.com/apple/FHIRModels", .upToNextMinor(from: "0.6.0")),
+        .package(url: "https://github.com/StanfordBDHG/HealthKitOnFHIR", .upToNextMinor(from: "0.2.11")),
+        .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.8.0"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziHealthKit", .upToNextMinor(from: "0.6.0")),
+        .package(url: "https://github.com/StanfordSpezi/SpeziLLM", .upToNextMinor(from: "0.8.4")),
+        .package(url: "https://github.com/StanfordSpezi/SpeziStorage", from: "1.2.1"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziChat", .upToNextMinor(from: "0.2.1")),
+        .package(url: "https://github.com/StanfordSpezi/SpeziSpeech", from: "1.1.0")
     ] + swiftLintPackage(),
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:6.0
 
 //
 // This source file is part of the Stanford Spezi open-source project
@@ -11,12 +11,6 @@
 import class Foundation.ProcessInfo
 import PackageDescription
 
-
-#if swift(<6)
-let strictConcurrency: SwiftSetting = .enableExperimentalFeature("StrictConcurrency")
-#else
-let strictConcurrency: SwiftSetting = .enableUpcomingFeature("StrictConcurrency")
-#endif
 
 let package = Package(
     name: "SpeziFHIR",
@@ -49,9 +43,6 @@ let package = Package(
                 .product(name: "ModelsDSTU2", package: "FHIRModels"),
                 .product(name: "HealthKitOnFHIR", package: "HealthKitOnFHIR")
             ],
-            swiftSettings: [
-                strictConcurrency
-            ],
             plugins: [] + swiftLintPlugin()
         ),
         .target(
@@ -60,9 +51,6 @@ let package = Package(
                 .target(name: "SpeziFHIR"),
                 .product(name: "HealthKitOnFHIR", package: "HealthKitOnFHIR"),
                 .product(name: "SpeziHealthKit", package: "SpeziHealthKit")
-            ],
-            swiftSettings: [
-                strictConcurrency
             ],
             plugins: [] + swiftLintPlugin()
         ),
@@ -81,9 +69,6 @@ let package = Package(
             resources: [
                 .process("Resources")
             ],
-            swiftSettings: [
-                strictConcurrency
-            ],
             plugins: [] + swiftLintPlugin()
         ),
         .target(
@@ -95,18 +80,12 @@ let package = Package(
             resources: [
                 .process("Resources")
             ],
-            swiftSettings: [
-                strictConcurrency
-            ],
             plugins: [] + swiftLintPlugin()
         ),
         .testTarget(
             name: "SpeziFHIRTests",
             dependencies: [
                 .target(name: "SpeziFHIR")
-            ],
-            swiftSettings: [
-                strictConcurrency
             ],
             plugins: [] + swiftLintPlugin()
         )

--- a/Sources/SpeziFHIR/Extensions/FHIR+Identifiable.swift
+++ b/Sources/SpeziFHIR/Extensions/FHIR+Identifiable.swift
@@ -9,9 +9,9 @@
 import ModelsR4
 
 
-extension Resource: Identifiable {
+extension Resource: @retroactive Identifiable {
     public typealias ID = FHIRPrimitive<FHIRString>?
 }
 
 
-extension FHIRPrimitive: Identifiable where PrimitiveType: Identifiable { }
+extension FHIRPrimitive: @retroactive Identifiable where PrimitiveType: Identifiable { }

--- a/Sources/SpeziFHIR/FHIRStore.swift
+++ b/Sources/SpeziFHIR/FHIRStore.swift
@@ -14,11 +14,14 @@ import enum ModelsDSTU2.ResourceProxy
 import Spezi
 
 
-/// Module to manage FHIR resources grouped into automatically computed and updated categories.
+/// `Module` to manage FHIR resources grouped into automatically computed and updated categories.
 ///
 /// The ``FHIRStore`` is automatically injected in the environment if you use the ``FHIR`` standard or can be used as a standalone module.
 @Observable
-public class FHIRStore: Module, EnvironmentAccessible, DefaultInitializable {
+public final class FHIRStore: Module,
+                              EnvironmentAccessible,
+                              DefaultInitializable,
+                              @unchecked Sendable /* `unchecked` `Sendable` conformance fine as access to `_resources` protected by `NSLock` */ {
     private let lock = NSLock()
     @ObservationIgnored private var _resources: [FHIRResource]
     

--- a/Sources/SpeziFHIRLLM/FHIRInterpretation/MultipleResources/FHIRMultipleResourceInterpreter.swift
+++ b/Sources/SpeziFHIRLLM/FHIRInterpretation/MultipleResources/FHIRMultipleResourceInterpreter.swift
@@ -101,6 +101,7 @@ public class FHIRMultipleResourceInterpreter {
     }
     
     /// Change the `LLMSchema` used by the ``FHIRMultipleResourceInterpreter``.
+    @MainActor
     public func changeLLMSchema(
         openAIModel model: LLMOpenAIModelType,
         resourceCountLimit: Int,
@@ -123,7 +124,7 @@ public class FHIRMultipleResourceInterpreter {
         }
         self.llm = nil
         
-        Task { @MainActor in
+        Task {
             await prepareLLM()
         }
     }

--- a/Sources/SpeziFHIRLLM/FHIRInterpretation/SingleResource/FHIRResourceInterpreter.swift
+++ b/Sources/SpeziFHIRLLM/FHIRInterpretation/SingleResource/FHIRResourceInterpreter.swift
@@ -14,7 +14,7 @@ import SpeziLocalStorage
 
 /// Responsible for interpreting FHIR resources.
 @Observable
-public class FHIRResourceInterpreter {
+public final class FHIRResourceInterpreter: Sendable {
     private let resourceProcessor: FHIRResourceProcessor<String>
     
     

--- a/Sources/SpeziFHIRLLM/FHIRInterpretationModule.swift
+++ b/Sources/SpeziFHIRLLM/FHIRInterpretationModule.swift
@@ -43,9 +43,9 @@ public class FHIRInterpretationModule: Module, DefaultInitializable {
     
     
     /// - Warning: Ensure that passed LLM schema's don't contain a system prompt! This will be configured by the ``FHIRInterpretationModule``.
-    public init<SummaryLLM: LLMSchema, InterpretationLLM: LLMSchema>(   // swiftlint:disable:this function_default_parameter_at_end
+    public init<SummaryLLM: LLMSchema, InterpretationLLM: LLMSchema>(
         summaryLLMSchema: SummaryLLM = Defaults.llmSchema,
-        interpretationLLMSchema: InterpretationLLM = Defaults.llmSchema,
+        interpretationLLMSchema: InterpretationLLM = Defaults.llmSchema,    // swiftlint:disable:this function_default_parameter_at_end
         multipleResourceInterpretationOpenAIModel: LLMOpenAIModelType,  // swiftlint:disable:this identifier_name
         resourceCountLimit: Int = 250,
         allowedResourcesFunctionCallIdentifiers: Set<String>? = nil // swiftlint:disable:this discouraged_optional_collection

--- a/Sources/SpeziFHIRLLM/FHIRInterpretationModule.swift
+++ b/Sources/SpeziFHIRLLM/FHIRInterpretationModule.swift
@@ -19,7 +19,7 @@ public class FHIRInterpretationModule: Module, DefaultInitializable {
         public static var llmSchema: LLMOpenAISchema {
             .init(
                 parameters: .init(
-                    modelType: .gpt4_turbo_preview,
+                    modelType: .gpt4_turbo,
                     systemPrompts: []   // No system prompt as this will be determined later by the resource interpreter
                 )
             )
@@ -27,9 +27,9 @@ public class FHIRInterpretationModule: Module, DefaultInitializable {
     }
     
     
-    @Dependency private var localStorage: LocalStorage
-    @Dependency private var llmRunner: LLMRunner
-    @Dependency private var fhirStore: FHIRStore
+    @Dependency(LocalStorage.self) private var localStorage
+    @Dependency(LLMRunner.self) private var llmRunner
+    @Dependency(FHIRStore.self) private var fhirStore
     
     @Model private var resourceSummary: FHIRResourceSummary
     @Model private var resourceInterpreter: FHIRResourceInterpreter
@@ -62,7 +62,7 @@ public class FHIRInterpretationModule: Module, DefaultInitializable {
         self.init(
             summaryLLMSchema: Defaults.llmSchema,
             interpretationLLMSchema: Defaults.llmSchema,
-            multipleResourceInterpretationOpenAIModel: .gpt4_turbo_preview
+            multipleResourceInterpretationOpenAIModel: .gpt4_turbo
         )
     }
     

--- a/Sources/SpeziFHIRLLM/FHIRProcessor/FHIRResourceProcessor.swift
+++ b/Sources/SpeziFHIRLLM/FHIRProcessor/FHIRResourceProcessor.swift
@@ -14,7 +14,8 @@ import SpeziLLMOpenAI
 import SpeziLocalStorage
 
 
-class FHIRResourceProcessor<Content: Codable & LosslessStringConvertible> {
+// Unchecked `Sendable` conformance is fine as storage is guarded by `NSLock`.
+final class FHIRResourceProcessor<Content: Codable & LosslessStringConvertible>: @unchecked Sendable {
     typealias Results = [FHIRResource.ID: Content]
     
     

--- a/Sources/SpeziFHIRLLM/FHIRSummary/FHIRResourceSummary.swift
+++ b/Sources/SpeziFHIRLLM/FHIRSummary/FHIRResourceSummary.swift
@@ -14,9 +14,9 @@ import SpeziLocalStorage
 
 /// Responsible for summarizing FHIR resources.
 @Observable
-public class FHIRResourceSummary {
+public final class FHIRResourceSummary: Sendable {
     /// Summary of a FHIR resource emitted by the ``FHIRResourceSummary``.
-    public struct Summary: Codable, LosslessStringConvertible {
+    public struct Summary: Codable, LosslessStringConvertible, Sendable {
         /// Title of the FHIR resource, should be shorter than 4 words.
         public let title: String
         /// Summary of the FHIR resource, should be a single line of text.

--- a/Sources/SpeziFHIRLLM/Settings/FHIRPrompt.swift
+++ b/Sources/SpeziFHIRLLM/Settings/FHIRPrompt.swift
@@ -10,7 +10,7 @@ import Foundation
 
 
 /// Handle dynamic, localized LLM prompts for FHIR resources.
-public struct FHIRPrompt: Hashable {
+public struct FHIRPrompt: Hashable, Sendable {
     /// Placeholder for FHIR resource in prompts.
     public static let fhirResourcePlaceholder = "{{FHIR_RESOURCE}}"
     /// Placeholder for the current locale in a prompt

--- a/Sources/SpeziFHIRMockPatients/FHIRBundle+MockPatients.swift
+++ b/Sources/SpeziFHIRMockPatients/FHIRBundle+MockPatients.swift
@@ -10,10 +10,11 @@ import Foundation
 import class ModelsR4.Bundle
 
 
-extension ModelsR4.Bundle {
+/// Fetches and stores mock patients in a structured Concurrency-safe way
+actor MockR4Bundles {
     private static var _jamison785Denesik803: ModelsR4.Bundle?
     /// Example FHIR resources packed into a bundle to represent the simulated patient named Jamison785 Denesik803.
-    public static var jamison785Denesik803: ModelsR4.Bundle {
+    static var jamison785Denesik803: ModelsR4.Bundle {
         get async {
             if let jamison785Denesik803 = _jamison785Denesik803 {
                 return jamison785Denesik803
@@ -22,14 +23,14 @@ extension ModelsR4.Bundle {
             let jamison785Denesik803 = await Foundation.Bundle.module.loadFHIRBundle(
                 withName: "Jamison785_Denesik803_1e08cb3f-9e6a-b083-b6ee-0bb38f70ba50"
             )
-            ModelsR4.Bundle._jamison785Denesik803 = jamison785Denesik803
+            Self._jamison785Denesik803 = jamison785Denesik803
             return jamison785Denesik803
         }
     }
     
     private static var _maye976Dickinson688: ModelsR4.Bundle?
     /// Example FHIR resources packed into a bundle to represent the simulated patient named Maye976 Dickinson688.
-    public static var maye976Dickinson688: ModelsR4.Bundle {
+    static var maye976Dickinson688: ModelsR4.Bundle {
         get async {
             if let maye976Dickinson688 = _maye976Dickinson688 {
                 return maye976Dickinson688
@@ -38,14 +39,14 @@ extension ModelsR4.Bundle {
             let maye976Dickinson688 = await Foundation.Bundle.module.loadFHIRBundle(
                 withName: "Maye976_Dickinson688_04f25f73-04b2-469c-3806-540417a0d61c"
             )
-            ModelsR4.Bundle._maye976Dickinson688 = maye976Dickinson688
+            Self._maye976Dickinson688 = maye976Dickinson688
             return maye976Dickinson688
         }
     }
     
     private static var _milagros256Hills818: ModelsR4.Bundle?
     /// Example FHIR resources packed into a bundle to represent the simulated patient named Milagros256 Hills818.
-    public static var milagros256Hills818: ModelsR4.Bundle {
+    static var milagros256Hills818: ModelsR4.Bundle {
         get async {
             if let milagros256Hills818 = _milagros256Hills818 {
                 return milagros256Hills818
@@ -54,14 +55,14 @@ extension ModelsR4.Bundle {
             let milagros256Hills818 = await Foundation.Bundle.module.loadFHIRBundle(
                 withName: "Milagros256_Hills818_79b1d90a-0eaf-be78-9bbf-91c638626012"
             )
-            ModelsR4.Bundle._milagros256Hills818 = milagros256Hills818
+            Self._milagros256Hills818 = milagros256Hills818
             return milagros256Hills818
         }
     }
     
     private static var _napoleon578Fay398: ModelsR4.Bundle?
     /// Example FHIR resources packed into a bundle to represent the simulated patient named Napoleon578 Fay398.
-    public static var napoleon578Fay398: ModelsR4.Bundle {
+    static var napoleon578Fay398: ModelsR4.Bundle {
         get async {
             if let napoleon578Fay398 = _napoleon578Fay398 {
                 return napoleon578Fay398
@@ -70,14 +71,14 @@ extension ModelsR4.Bundle {
             let napoleon578Fay398 = await Foundation.Bundle.module.loadFHIRBundle(
                 withName: "Napoleon578_Fay398_38f38890-b80f-6542-51d4-882c7b37b0bf"
             )
-            ModelsR4.Bundle._napoleon578Fay398 = napoleon578Fay398
+            Self._napoleon578Fay398 = napoleon578Fay398
             return napoleon578Fay398
         }
     }
     
     private static var _allen322Ferry570: ModelsR4.Bundle?
     /// Example FHIR resources packed into a bundle to represent the simulated patient named Allen322 Ferry570.
-    public static var allen322Ferry570: ModelsR4.Bundle {
+    static var allen322Ferry570: ModelsR4.Bundle {
         get async {
             if let allen322Ferry570 = _allen322Ferry570 {
                 return allen322Ferry570
@@ -86,14 +87,14 @@ extension ModelsR4.Bundle {
             let allen322Ferry570 = await Foundation.Bundle.main.loadFHIRBundle(
                 withName: "Allen322_Ferry570_ad134528-56a5-35fd-c37f-466ff119c625"
             )
-            ModelsR4.Bundle._allen322Ferry570 = allen322Ferry570
+            self._allen322Ferry570 = allen322Ferry570
             return allen322Ferry570
         }
     }
     
     private static var _beatris270Bogan287: ModelsR4.Bundle?
     /// Example FHIR resources packed into a bundle to represent the simulated patient named Beatris270 Bogan287.
-    public static var beatris270Bogan287: ModelsR4.Bundle {
+    static var beatris270Bogan287: ModelsR4.Bundle {
         get async {
             if let beatris270Bogan287 = _beatris270Bogan287 {
                 return beatris270Bogan287
@@ -102,14 +103,14 @@ extension ModelsR4.Bundle {
             let beatris270Bogan287 = await Foundation.Bundle.main.loadFHIRBundle(
                 withName: "Beatris270_Bogan287_5b3645de-a2d0-d016-0839-bab3757c4c58"
             )
-            ModelsR4.Bundle._beatris270Bogan287 = beatris270Bogan287
+            Self._beatris270Bogan287 = beatris270Bogan287
             return beatris270Bogan287
         }
     }
     
     private static var _edythe31Morar593: ModelsR4.Bundle?
     /// Example FHIR resources packed into a bundle to represent the simulated patient named Edythe31 Morar593.
-    public static var edythe31Morar593: ModelsR4.Bundle {
+    static var edythe31Morar593: ModelsR4.Bundle {
         get async {
             if let edythe31Morar593 = _edythe31Morar593 {
                 return edythe31Morar593
@@ -118,14 +119,14 @@ extension ModelsR4.Bundle {
             let edythe31Morar593 = await Foundation.Bundle.main.loadFHIRBundle(
                 withName: "Edythe31_Morar593_9c3df38a-d3b7-2198-3898-51f9153d023d"
             )
-            ModelsR4.Bundle._edythe31Morar593 = edythe31Morar593
+            Self._edythe31Morar593 = edythe31Morar593
             return edythe31Morar593
         }
     }
     
     private static var _gonzalo160Duenas839: ModelsR4.Bundle?
     /// Example FHIR resources packed into a bundle to represent the simulated patient named Gonzalo160 Duenas839.
-    public static var gonzalo160Duenas839: ModelsR4.Bundle {
+    static var gonzalo160Duenas839: ModelsR4.Bundle {
         get async {
             if let gonzalo160Duenas839 = _gonzalo160Duenas839 {
                 return gonzalo160Duenas839
@@ -134,14 +135,14 @@ extension ModelsR4.Bundle {
             let gonzalo160Duenas839 = await Foundation.Bundle.main.loadFHIRBundle(
                 withName: "Gonzalo160_Duenas839_ed70a28f-30b2-acb7-658a-8b340dadd685"
             )
-            ModelsR4.Bundle._gonzalo160Duenas839 = gonzalo160Duenas839
+            Self._gonzalo160Duenas839 = gonzalo160Duenas839
             return gonzalo160Duenas839
         }
     }
     
     private static var _jacklyn830Veum823: ModelsR4.Bundle?
     /// Example FHIR resources packed into a bundle to represent the simulated patient named Jacklyn830 Veum823.
-    public static var jacklyn830Veum823: ModelsR4.Bundle {
+    static var jacklyn830Veum823: ModelsR4.Bundle {
         get async {
             if let jacklyn830Veum823 = _jacklyn830Veum823 {
                 return jacklyn830Veum823
@@ -150,14 +151,14 @@ extension ModelsR4.Bundle {
             let jacklyn830Veum823 = await Foundation.Bundle.main.loadFHIRBundle(
                 withName: "Jacklyn830_Veum823_e0e1f21a-22a7-d166-7bb1-63f6bbce1a32"
             )
-            ModelsR4.Bundle._jacklyn830Veum823 = jacklyn830Veum823
+            Self._jacklyn830Veum823 = jacklyn830Veum823
             return jacklyn830Veum823
         }
     }
     
     private static var _milton509Ortiz186: ModelsR4.Bundle?
     /// Example FHIR resources packed into a bundle to represent the simulated patient named Milton509 Ortiz186.
-    public static var milton509Ortiz186: ModelsR4.Bundle {
+    static var milton509Ortiz186: ModelsR4.Bundle {
         get async {
             if let milton509Ortiz186 = _milton509Ortiz186 {
                 return milton509Ortiz186
@@ -166,8 +167,81 @@ extension ModelsR4.Bundle {
             let milton509Ortiz186 = await Foundation.Bundle.main.loadFHIRBundle(
                 withName: "Milton509_Ortiz186_d66b5418-06cb-fc8a-8c13-85685b6ac939"
             )
-            ModelsR4.Bundle._milton509Ortiz186 = milton509Ortiz186
+            Self._milton509Ortiz186 = milton509Ortiz186
             return milton509Ortiz186
+        }
+    }
+}
+
+
+extension ModelsR4.Bundle {
+    /// Example FHIR resources packed into a bundle to represent the simulated patient named Jamison785 Denesik803.
+    public static var jamison785Denesik803: ModelsR4.Bundle {
+        get async {
+            await MockR4Bundles.jamison785Denesik803
+        }
+    }
+    
+    /// Example FHIR resources packed into a bundle to represent the simulated patient named Maye976 Dickinson688.
+    public static var maye976Dickinson688: ModelsR4.Bundle {
+        get async {
+            await MockR4Bundles.maye976Dickinson688
+        }
+    }
+    
+    /// Example FHIR resources packed into a bundle to represent the simulated patient named Milagros256 Hills818.
+    public static var milagros256Hills818: ModelsR4.Bundle {
+        get async {
+            await MockR4Bundles.milagros256Hills818
+        }
+    }
+    
+    /// Example FHIR resources packed into a bundle to represent the simulated patient named Napoleon578 Fay398.
+    public static var napoleon578Fay398: ModelsR4.Bundle {
+        get async {
+            await MockR4Bundles.napoleon578Fay398
+        }
+    }
+    
+    /// Example FHIR resources packed into a bundle to represent the simulated patient named Allen322 Ferry570.
+    public static var allen322Ferry570: ModelsR4.Bundle {
+        get async {
+            await MockR4Bundles.allen322Ferry570
+        }
+    }
+    
+    /// Example FHIR resources packed into a bundle to represent the simulated patient named Beatris270 Bogan287.
+    public static var beatris270Bogan287: ModelsR4.Bundle {
+        get async {
+            await MockR4Bundles.beatris270Bogan287
+        }
+    }
+    
+    /// Example FHIR resources packed into a bundle to represent the simulated patient named Edythe31 Morar593.
+    public static var edythe31Morar593: ModelsR4.Bundle {
+        get async {
+            await MockR4Bundles.edythe31Morar593
+        }
+    }
+    
+    /// Example FHIR resources packed into a bundle to represent the simulated patient named Gonzalo160 Duenas839.
+    public static var gonzalo160Duenas839: ModelsR4.Bundle {
+        get async {
+            await MockR4Bundles.gonzalo160Duenas839
+        }
+    }
+    
+    /// Example FHIR resources packed into a bundle to represent the simulated patient named Jacklyn830 Veum823.
+    public static var jacklyn830Veum823: ModelsR4.Bundle {
+        get async {
+            await MockR4Bundles.jacklyn830Veum823
+        }
+    }
+    
+    /// Example FHIR resources packed into a bundle to represent the simulated patient named Milton509 Ortiz186.
+    public static var milton509Ortiz186: ModelsR4.Bundle {
+        get async {
+            await MockR4Bundles.milton509Ortiz186
         }
     }
     

--- a/Tests/UITests/UITests.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Tests/UITests/UITests.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/FHIRModels",
       "state" : {
-        "revision" : "861afd5816a98d38f86220eab2f812d76cad84a0",
-        "version" : "0.5.0"
+        "revision" : "8a1cb1bdc4a01a814825aca47ada4186dc8a6ee1",
+        "version" : "0.6.0"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordBDHG/HealthKitOnFHIR",
       "state" : {
-        "revision" : "418929f315f37e6d9c8f30f40030bc65b9cc47c9",
-        "version" : "0.2.8"
+        "revision" : "87a9257e6fa37407f3437e4a0bf21dd09a4ea7c5",
+        "version" : "0.2.11"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/Spezi",
       "state" : {
-        "revision" : "5ada3f3a18c86a658d140c6f4c45ca2e9d5e61ce",
-        "version" : "1.4.0"
+        "revision" : "4513a697572e8e1faea1e0ee52e6fad4b8d3dd8d",
+        "version" : "1.8.0"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziChat.git",
       "state" : {
-        "revision" : "aaa10d71431b78ece8bf29f95c0050632714984d",
-        "version" : "0.2.0"
+        "revision" : "940ffbec504849968305d9f956344a4f35b6cd48",
+        "version" : "0.2.1"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziFoundation",
       "state" : {
-        "revision" : "3326feab3dac120c16af63243615592990d33516",
-        "version" : "1.1.2"
+        "revision" : "5b4ad1b343154b52a68c33a6bfe02d9cb07cb9dc",
+        "version" : "2.0.0"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziHealthKit.git",
       "state" : {
-        "revision" : "1e9cb5a6036ac7f4ff37ea1c3ed4898103339ad1",
-        "version" : "0.5.3"
+        "revision" : "fbdec78fcb2f90d6338f1968e21dd11fbee65070",
+        "version" : "0.6.0"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziLLM.git",
       "state" : {
-        "revision" : "3663884f23e55c67c875a97c5da08ed172ea02ac",
-        "version" : "0.8.3"
+        "revision" : "6633d8a78eece57d18a9876197e5806c01516343",
+        "version" : "0.8.4"
       }
     },
     {
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziSpeech",
       "state" : {
-        "revision" : "60b8cdbf6f3d58b0d75eadf30db50f88848069aa",
-        "version" : "1.0.1"
+        "revision" : "0b79f72fc8b0606e09787926446dfafb541669d3",
+        "version" : "1.2.0"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziStorage",
       "state" : {
-        "revision" : "b958df9b31f24800388a7bfc28f457ce7b82556c",
-        "version" : "1.0.2"
+        "revision" : "0f4a54430e51f82d29da63a7ce5f61bad7dfb9cd",
+        "version" : "1.2.1"
       }
     },
     {
@@ -115,6 +115,15 @@
       "state" : {
         "revision" : "ff61e6594677572df051b96905cc2a7a12cffd10",
         "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
+        "version" : "1.2.0"
       }
     },
     {
@@ -131,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordBDHG/XCTRuntimeAssertions",
       "state" : {
-        "revision" : "51da3403f128b120705571ce61e0fe190f8889e6",
-        "version" : "1.0.1"
+        "revision" : "f560ec8410af032dd485ca9386e8c2b5d3e1a1f8",
+        "version" : "1.1.3"
       }
     }
   ],


### PR DESCRIPTION
# Swift 6 language mode readiness and bump dependencies

## :recycle: Current situation & Problem
As the repo wasn't properly maintained for quite some months, most dependencies have been severely outdated.

## :gear: Release Notes 
- Swift 6 language mode readiness
- Bump dependencies to the newest versions


## :books: Documentation
--


## :white_check_mark: Testing
Tested locally and UI tests passing


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
