### PR TITLE
`FHIRStore` actor isolation

### DIFF
--- a/Sources/SpeziFHIR/FHIRResource/FHIRResource+Category.swift
+++ b/Sources/SpeziFHIR/FHIRResource/FHIRResource+Category.swift
@@ -36,7 +36,10 @@ extension FHIRResource {
         case other
 
 
-        var storeKeyPath: KeyPath<FHIRStore, [FHIRResource]> {
+        /// The ``FHIRStore`` property key path of the resource.
+        ///
+        /// - Note: Needs to be isolated on `MainActor` as the respective ``FHIRStore`` properties referred to by the `KeyPath` are isolated on the `MainActor`.
+        @MainActor var storeKeyPath: KeyPath<FHIRStore, [FHIRResource]> {
             switch self {
             case .observation: \.observations
             case .encounter: \.encounters
@@ -50,13 +53,8 @@ extension FHIRResource {
             }
         }
     }
-
-
-    /// The ``FHIRStore`` property key path of the resource.
-    var storeKeyPath: KeyPath<FHIRStore, [FHIRResource]> {
-        self.category.storeKeyPath
-    }
     
+
     /// Category of the FHIR resource.
     ///
     /// Analyzes the type of the underlying resource and assigns it to an appropriate category.

--- a/Sources/SpeziFHIR/FHIRResource/FHIRResource+Category.swift
+++ b/Sources/SpeziFHIR/FHIRResource/FHIRResource+Category.swift
@@ -15,7 +15,7 @@ import enum ModelsDSTU2.ResourceProxy
 extension FHIRResource {
     /// Enum representing different categories of FHIR resources.
     /// This categorization helps in classifying FHIR resources into common healthcare scenarios and types.
-    enum FHIRResourceCategory {
+    enum FHIRResourceCategory: CaseIterable {
         /// Represents an observation-type resource (e.g., patient measurements, lab results).
         case observation
         /// Represents an encounter-type resource (e.g., patient visits, admissions).
@@ -34,22 +34,27 @@ extension FHIRResource {
         case medication
         /// Represents other types of resources not covered by the above categories.
         case other
+
+
+        var storeKeyPath: KeyPath<FHIRStore, [FHIRResource]> {
+            switch self {
+            case .observation: \.observations
+            case .encounter: \.encounters
+            case .condition: \.conditions
+            case .diagnostic: \.diagnostics
+            case .procedure: \.procedures
+            case .immunization: \.immunizations
+            case .allergyIntolerance: \.allergyIntolerances
+            case .medication: \.medications
+            case .other: \.otherResources
+            }
+        }
     }
 
 
     /// The ``FHIRStore`` property key path of the resource.
     var storeKeyPath: KeyPath<FHIRStore, [FHIRResource]> {
-        switch self.category {
-        case .observation: \.observations
-        case .encounter: \.encounters
-        case .condition: \.conditions
-        case .diagnostic: \.diagnostics
-        case .procedure: \.procedures
-        case .immunization: \.immunizations
-        case .allergyIntolerance: \.allergyIntolerances
-        case .medication: \.medications
-        case .other: \.otherResources
-        }
+        self.category.storeKeyPath
     }
     
     /// Category of the FHIR resource.

--- a/Sources/SpeziFHIR/FHIRResource/FHIRResource+Category.swift
+++ b/Sources/SpeziFHIR/FHIRResource/FHIRResource+Category.swift
@@ -35,31 +35,23 @@ extension FHIRResource {
         /// Represents other types of resources not covered by the above categories.
         case other
     }
-    
+
+
+    /// The ``FHIRStore`` property key path of the resource.
     var storeKeyPath: KeyPath<FHIRStore, [FHIRResource]> {
         switch self.category {
-        case .observation:
-            \.observations
-        case .encounter:
-            \.encounters
-        case .condition:
-            \.conditions
-        case .diagnostic:
-            \.diagnostics
-        case .procedure:
-            \.procedures
-        case .immunization:
-            \.immunizations
-        case .allergyIntolerance:
-            \.allergyIntolerances
-        case .medication:
-            \.medications
-        case .other:
-            \.otherResources
+        case .observation: \.observations
+        case .encounter: \.encounters
+        case .condition: \.conditions
+        case .diagnostic: \.diagnostics
+        case .procedure: \.procedures
+        case .immunization: \.immunizations
+        case .allergyIntolerance: \.allergyIntolerances
+        case .medication: \.medications
+        case .other: \.otherResources
         }
     }
     
-        
     /// Category of the FHIR resource.
     ///
     /// Analyzes the type of the underlying resource and assigns it to an appropriate category.

--- a/Sources/SpeziFHIR/FHIRResource/FHIRResource.swift
+++ b/Sources/SpeziFHIR/FHIRResource/FHIRResource.swift
@@ -7,19 +7,19 @@
 //
 
 import Foundation
-@preconcurrency import ModelsDSTU2
-@preconcurrency import ModelsR4
+import ModelsDSTU2
+import ModelsR4
 
 
 /// Represents a FHIR (Fast Healthcare Interoperability Resources) entity.
 ///
 /// Handles both DSTU2 and R4 versions, providing a unified interface to interact with different FHIR versions.
-public struct FHIRResource: Sendable, Identifiable, Hashable {
+public struct FHIRResource: Identifiable, Hashable {
     /// Version-specific FHIR resources.
-    public enum VersionedFHIRResource: Sendable, Hashable {
+    public enum VersionedFHIRResource: Hashable {
         /// R4 version of FHIR resources.
         case r4(ModelsR4.Resource) // swiftlint:disable:this identifier_name
-        // DSTU2 version of FHIR resources.
+        /// DSTU2 version of FHIR resources.
         case dstu2(ModelsDSTU2.Resource)
     }
     

--- a/Sources/SpeziFHIR/FHIRStore.swift
+++ b/Sources/SpeziFHIR/FHIRStore.swift
@@ -144,7 +144,7 @@ public final class FHIRStore: Module,
     ///
     /// - Parameter resource: The `FHIRResource` identifier to be inserted.
     @MainActor
-    public func remove(resource resourceId: FHIRResource.ID) async {
+    public func remove(resource resourceId: FHIRResource.ID) {
         guard let resource = _resources.first(where: { $0.id == resourceId }) else {
             return
         }

--- a/Sources/SpeziFHIR/FHIRStore.swift
+++ b/Sources/SpeziFHIR/FHIRStore.swift
@@ -116,7 +116,7 @@ public final class FHIRStore: Module,
     /// Loads resources from a given FHIR `Bundle` into the ``FHIRStore``.
     ///
     /// - Parameter bundle: The FHIR `Bundle` containing resources to be loaded.
-    public func load(bundle: Bundle) async {
+    public func load(bundle: sending Bundle) async {
         let resourceProxies = bundle.entry?.compactMap { $0.resource } ?? []
         var resources: [FHIRResource] = []
 

--- a/Sources/SpeziFHIR/FHIRStore.swift
+++ b/Sources/SpeziFHIR/FHIRStore.swift
@@ -27,17 +27,16 @@ public final class FHIRStore: Module,
         nonisolated(unsafe) private var _resources: [FHIRResource] = []
 
 
-        var resourceIds: [FHIRResource.ID] {
-            _resources.map(\.id)
-        }
-
-
         func insert(resource: FHIRResource) {
             _resources.append(resource)
         }
 
         func remove(resource resourceId: FHIRResource.ID) {
             _resources.removeAll { $0.id == resourceId }
+        }
+
+        func removeAll() {
+            _resources = []
         }
 
         nonisolated func fetch(for category: FHIRResource.FHIRResourceCategory) -> [FHIRResource] {
@@ -155,8 +154,14 @@ public final class FHIRStore: Module,
 
     /// Removes all resources from the ``FHIRStore``.
     public func removeAllResources() async {
-        for resourceId in await storage.resourceIds {
-            await self.remove(resource: resourceId)
+        for category in FHIRResource.FHIRResourceCategory.allCases {
+            _$observationRegistrar.willSet(self, keyPath: category.storeKeyPath)
+        }
+
+        await storage.removeAll()
+
+        for category in FHIRResource.FHIRResourceCategory.allCases {
+            _$observationRegistrar.didSet(self, keyPath: category.storeKeyPath)
         }
     }
 }

--- a/Sources/SpeziFHIR/FHIRStore.swift
+++ b/Sources/SpeziFHIR/FHIRStore.swift
@@ -97,19 +97,18 @@ public final class FHIRStore: Module,
     /// Inserts a ``Collection`` of FHIR resources into the ``FHIRStore``.
     ///
     /// - Parameter resources: The `FHIRResource`s to be inserted.
-    public func insert<T: Collection>(resources: sending T) async where T.Element == FHIRResource {
-        let resourceCategories = Set(resources.map { $0.category })
+    @MainActor
+    public func insert<T: Collection>(resources: T) where T.Element == FHIRResource {
+        let resourceCategories = Set(resources.map(\.category))
 
-        await MainActor.run {
-            for category in resourceCategories {
-                _$observationRegistrar.willSet(self, keyPath: category.storeKeyPath)
-            }
+        for category in resourceCategories {
+            _$observationRegistrar.willSet(self, keyPath: category.storeKeyPath)
+        }
 
-            self._resources.append(contentsOf: resources)
+        self._resources.append(contentsOf: resources)
 
-            for category in resourceCategories {
-                _$observationRegistrar.didSet(self, keyPath: category.storeKeyPath)
-            }
+        for category in resourceCategories {
+            _$observationRegistrar.didSet(self, keyPath: category.storeKeyPath)
         }
     }
 

--- a/Sources/SpeziFHIRHealthKit/FHIRStore+HealthKit.swift
+++ b/Sources/SpeziFHIRHealthKit/FHIRStore+HealthKit.swift
@@ -29,7 +29,7 @@ extension FHIRStore {
     public func add(sample: HKSample) async {
         do {
             let resource = try await transform(sample: sample)
-            insert(resource: resource)
+            await insert(resource: resource)
         } catch {
             print("Could not transform HKSample: \(error)")
         }
@@ -38,7 +38,7 @@ extension FHIRStore {
     /// Remove a HealthKit sample delete object from the FHIR store.
     /// - Parameter sample: The sample delete object that should be removed.
     public func remove(sample: HKDeletedObject) async {
-        remove(resource: sample.uuid.uuidString)
+        await remove(resource: sample.uuid.uuidString)
     }
     
     

--- a/Sources/SpeziFHIRMockPatients/FHIRBundleSelector.swift
+++ b/Sources/SpeziFHIRMockPatients/FHIRBundleSelector.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-@preconcurrency import class ModelsR4.Bundle
+import class ModelsR4.Bundle
 import class ModelsR4.Patient
 import SpeziFHIR
 import SwiftUI
@@ -16,7 +16,7 @@ import SwiftUI
 ///
 /// The View assumes that the bundle contains a `ModelsR4.Patient` resource to identify the bundle and provide a human-readable name.
 public struct FHIRBundleSelector: View {
-    private struct PatientIdentifiedBundle: Identifiable, Sendable {
+    private struct PatientIdentifiedBundle: Identifiable {
         let id: String
         let bundle: ModelsR4.Bundle
     }
@@ -73,7 +73,7 @@ public struct FHIRBundleSelector: View {
 
                 store.removeAllResources()
 
-                fhirResourceLoadingTask = Task.detached {
+                fhirResourceLoadingTask = Task {
                     await store.load(bundle: selected.bundle)
                 }
             }

--- a/Sources/SpeziFHIRMockPatients/FHIRMockBundleSelector.swift
+++ b/Sources/SpeziFHIRMockPatients/FHIRMockBundleSelector.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-@preconcurrency import ModelsR4
+import ModelsR4
 import SwiftUI
 
 
@@ -31,7 +31,12 @@ public struct FHIRMockPatientSelection: View {
             }
         }
             .task {
-                self.bundles = await ModelsR4.Bundle.mockPatients
+                _Concurrency.Task.detached {    // Workaround but enables us to not mark `import ModelsR4` as `@preconcurrency`
+                    let bundles = await ModelsR4.Bundle.mockPatients
+                    await MainActor.run {
+                        self.bundles = bundles
+                    }
+                }
             }
     }
     

--- a/Sources/SpeziFHIRMockPatients/FHIRStore+TestingSupport.swift
+++ b/Sources/SpeziFHIRMockPatients/FHIRStore+TestingSupport.swift
@@ -12,7 +12,7 @@ import SpeziFHIR
 
 extension FHIRStore {
     /// Loads a mock resource into the `FHIRStore` for testing purposes.
-    public func loadTestingResources() {
+    public func loadTestingResources() async {
         let mockObservation = Observation(
             code: CodeableConcept(coding: [Coding(code: "1234".asFHIRStringPrimitive())]),
             id: FHIRPrimitive<FHIRString>("1234"),
@@ -25,7 +25,7 @@ extension FHIRStore {
             displayName: "Mock Resource"
         )
         
-        removeAllResources()
-        insert(resource: mockFHIRResource)
+        await removeAllResources()
+        await insert(resource: mockFHIRResource)
     }
 }

--- a/Sources/SpeziFHIRMockPatients/FoundationBundle+LoadBundle.swift
+++ b/Sources/SpeziFHIRMockPatients/FoundationBundle+LoadBundle.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-@preconcurrency import class ModelsR4.Bundle
+import class ModelsR4.Bundle
 
 
 extension Foundation.Bundle {
@@ -18,14 +18,12 @@ extension Foundation.Bundle {
         guard let resourceURL = Self.module.url(forResource: name, withExtension: "json") else {
             fatalError("Could not find the resource \"\(name)\".json in the SpeziFHIRMockPatients Resources folder.")
         }
-        
-        let loadingTask = Task {
-            let resourceData = try Data(contentsOf: resourceURL)
-            return try JSONDecoder().decode(Bundle.self, from: resourceData)
-        }
-        
+
         do {
-            return try await loadingTask.value
+            return try JSONDecoder().decode(
+                Bundle.self,
+                from: Data(contentsOf: resourceURL)
+            )
         } catch {
             fatalError("Could not decode the FHIR bundle named \"\(name).json\": \(error)")
         }

--- a/Tests/UITests/TestApp/ContentView.swift
+++ b/Tests/UITests/TestApp/ContentView.swift
@@ -14,10 +14,12 @@ import SwiftUI
 struct ContentView: View {
     @Environment(FHIRStore.self) private var fhirStore
     @State private var presentPatientSelection = false
-    
+
+    private let additionalFHIRResourceId = "SuperUniqueFHIRResourceIdentifier"
+
     
     var body: some View {
-        NavigationStack {
+        NavigationStack {   // swiftlint:disable:this closure_body_length
             List {
                 Section {
                     Text("Allergy Intolerances: \(fhirStore.allergyIntolerances.count)")
@@ -42,13 +44,22 @@ struct ContentView: View {
                         Button {
                             fhirStore.insert(
                                 resource: .init(
-                                    resource: ModelsR4.Account(id: "SuperUniqueFHIRResourceIdentifier", status: .init()),
+                                    resource: ModelsR4.Account(id: .init(stringLiteral: additionalFHIRResourceId), status: .init()),
                                     displayName: "Random Account FHIR Resource"
                                 )
                             )
                         } label: {
                             Label("Add", systemImage: "doc.badge.plus")
                                 .accessibilityLabel("Add FHIR Resource")
+                        }
+                    }
+
+                    ToolbarItem(placement: .automatic) {
+                        Button {
+                            fhirStore.remove(resource: additionalFHIRResourceId)
+                        } label: {
+                            Label("Remove", systemImage: "minus.circle.fill")
+                                .accessibilityLabel("Remove FHIR Resource")
                         }
                     }
                 }

--- a/Tests/UITests/TestApp/ContentView.swift
+++ b/Tests/UITests/TestApp/ContentView.swift
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
+import ModelsR4
 import SpeziFHIR
 import SwiftUI
 
@@ -35,6 +36,21 @@ struct ContentView: View {
             }
                 .sheet(isPresented: $presentPatientSelection) {
                     MockPatientSelection(presentPatientSelection: $presentPatientSelection)
+                }
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        Button {
+                            fhirStore.insert(
+                                resource: .init(
+                                    resource: ModelsR4.Account(id: "SuperUniqueFHIRResourceIdentifier", status: .init()),
+                                    displayName: "Random Account FHIR Resource"
+                                )
+                            )
+                        } label: {
+                            Label("Add", systemImage: "doc.badge.plus")
+                                .accessibilityLabel("Add FHIR Resource")
+                        }
+                    }
                 }
         }
     }

--- a/Tests/UITests/TestApp/ContentView.swift
+++ b/Tests/UITests/TestApp/ContentView.swift
@@ -11,8 +11,8 @@ import SwiftUI
 
 
 struct ContentView: View {
-    @Environment(FHIRStore.self) var fhirStore
-    @State var presentPatientSelection = false
+    @Environment(FHIRStore.self) private var fhirStore
+    @State private var presentPatientSelection = false
     
     
     var body: some View {
@@ -26,8 +26,8 @@ struct ContentView: View {
                     Text("Immunizations: \(fhirStore.immunizations.count)")
                     Text("Medications: \(fhirStore.medications.count)")
                     Text("Observations: \(fhirStore.observations.count)")
-                    Text("Other Resources: \(fhirStore.otherResources.count)")
                     Text("Procedures: \(fhirStore.procedures.count)")
+                    Text("Other Resources: \(fhirStore.otherResources.count)")
                 }
                 Section {
                     presentPatientSelectionButton

--- a/Tests/UITests/TestApp/ContentView.swift
+++ b/Tests/UITests/TestApp/ContentView.swift
@@ -54,11 +54,11 @@ struct ContentView: View {
                         }
                     }
 
-                    ToolbarItem(placement: .automatic) {
+                    ToolbarItem {
                         Button {
                             fhirStore.remove(resource: additionalFHIRResourceId)
                         } label: {
-                            Label("Remove", systemImage: "minus.circle.fill")
+                            Label("Remove", systemImage: "folder.badge.minus")
                                 .accessibilityLabel("Remove FHIR Resource")
                         }
                     }

--- a/Tests/UITests/TestAppUITests/FHIRMockDataStorageProviderTests.swift
+++ b/Tests/UITests/TestAppUITests/FHIRMockDataStorageProviderTests.swift
@@ -21,9 +21,9 @@ final class SpeziFHIRTests: XCTestCase {
         XCTAssert(app.staticTexts["Immunizations: 0"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Medications: 0"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Observations: 0"].waitForExistence(timeout: 2))
-        XCTAssert(app.staticTexts["Other Resources: 0"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Procedures: 0"].waitForExistence(timeout: 2))
-        
+        XCTAssert(app.staticTexts["Other Resources: 0"].waitForExistence(timeout: 2))
+
         app.buttons["Select Mock Patient"].tap()
         
         XCTAssert(app.buttons["Jamison785 Denesik803"].waitForExistence(timeout: 20))
@@ -38,9 +38,9 @@ final class SpeziFHIRTests: XCTestCase {
         XCTAssert(app.staticTexts["Immunizations: 12"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Medications: 31"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Observations: 769"].waitForExistence(timeout: 2))
-        XCTAssert(app.staticTexts["Other Resources: 302"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Procedures: 106"].waitForExistence(timeout: 2))
-        
+        XCTAssert(app.staticTexts["Other Resources: 302"].waitForExistence(timeout: 2))
+
         app.buttons["Select Mock Patient"].tap()
         
         XCTAssert(app.buttons["Maye976 Dickinson688"].waitForExistence(timeout: 20))
@@ -55,7 +55,7 @@ final class SpeziFHIRTests: XCTestCase {
         XCTAssert(app.staticTexts["Immunizations: 11"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Medications: 55"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Observations: 169"].waitForExistence(timeout: 2))
-        XCTAssert(app.staticTexts["Other Resources: 322"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Procedures: 225"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Other Resources: 322"].waitForExistence(timeout: 2))
     }
 }

--- a/Tests/UITests/TestAppUITests/FHIRMockDataStorageProviderTests.swift
+++ b/Tests/UITests/TestAppUITests/FHIRMockDataStorageProviderTests.swift
@@ -10,7 +10,7 @@ import XCTest
 
 
 final class SpeziFHIRTests: XCTestCase {
-    func testSpeziFHIRMockPatients() throws {
+    func testMockPatientResources() throws {
         let app = XCUIApplication()
         app.launch()
         
@@ -24,8 +24,9 @@ final class SpeziFHIRTests: XCTestCase {
         XCTAssert(app.staticTexts["Procedures: 0"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Other Resources: 0"].waitForExistence(timeout: 2))
 
+        XCTAssert(app.buttons["Select Mock Patient"].waitForExistence(timeout: 2))
         app.buttons["Select Mock Patient"].tap()
-        
+
         XCTAssert(app.buttons["Jamison785 Denesik803"].waitForExistence(timeout: 20))
         app.buttons["Jamison785 Denesik803"].tap()
         
@@ -41,8 +42,9 @@ final class SpeziFHIRTests: XCTestCase {
         XCTAssert(app.staticTexts["Procedures: 106"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Other Resources: 302"].waitForExistence(timeout: 2))
 
+        XCTAssert(app.buttons["Select Mock Patient"].waitForExistence(timeout: 2))
         app.buttons["Select Mock Patient"].tap()
-        
+
         XCTAssert(app.buttons["Maye976 Dickinson688"].waitForExistence(timeout: 20))
         app.buttons["Maye976 Dickinson688"].tap()
         
@@ -57,5 +59,59 @@ final class SpeziFHIRTests: XCTestCase {
         XCTAssert(app.staticTexts["Observations: 169"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Procedures: 225"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Other Resources: 322"].waitForExistence(timeout: 2))
+    }
+
+    func testAddingAndRemovingResources() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Add 5 resources
+        for resourceCount in 0..<5 {
+            XCTAssert(app.staticTexts["Other Resources: \(resourceCount)"].waitForExistence(timeout: 2))
+
+            XCTAssert(app.buttons["Add FHIR Resource"].waitForExistence(timeout: 2))
+            app.buttons["Add FHIR Resource"].tap()
+        }
+
+        // Remove added resources
+        XCTAssert(app.buttons["Remove FHIR Resource"].waitForExistence(timeout: 2))
+        app.buttons["Remove FHIR Resource"].tap()
+
+        XCTAssert(app.staticTexts["Other Resources: 0"].waitForExistence(timeout: 2))
+
+        // Try removing a second time
+        XCTAssert(app.buttons["Remove FHIR Resource"].waitForExistence(timeout: 2))
+        app.buttons["Remove FHIR Resource"].tap()
+
+        XCTAssert(app.staticTexts["Other Resources: 0"].waitForExistence(timeout: 2))
+
+        // Select mock patient
+        XCTAssert(app.buttons["Select Mock Patient"].waitForExistence(timeout: 2))
+        app.buttons["Select Mock Patient"].tap()
+
+        XCTAssert(app.buttons["Jamison785 Denesik803"].waitForExistence(timeout: 20))
+        app.buttons["Jamison785 Denesik803"].tap()
+
+        app.navigationBars["Select Mock Patient"].buttons["Dismiss"].tap()
+
+        XCTAssert(app.staticTexts["Other Resources: 302"].waitForExistence(timeout: 2))
+
+        // Add resource to mock patient
+        XCTAssert(app.buttons["Add FHIR Resource"].waitForExistence(timeout: 2))
+        app.buttons["Add FHIR Resource"].tap()
+
+        XCTAssert(app.staticTexts["Other Resources: 303"].waitForExistence(timeout: 2))
+
+        // Remove resource from mock patient
+        XCTAssert(app.buttons["Remove FHIR Resource"].waitForExistence(timeout: 2))
+        app.buttons["Remove FHIR Resource"].tap()
+
+        XCTAssert(app.staticTexts["Other Resources: 302"].waitForExistence(timeout: 2))
+
+        // Try removing a second time
+        XCTAssert(app.buttons["Remove FHIR Resource"].waitForExistence(timeout: 2))
+        app.buttons["Remove FHIR Resource"].tap()
+
+        XCTAssert(app.staticTexts["Other Resources: 302"].waitForExistence(timeout: 2))
     }
 }

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -164,7 +164,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1410;
-				LastUpgradeCheck = 1500;
+				LastUpgradeCheck = 1620;
 				TargetAttributes = {
 					2F6D139128F5F384007C25D6 = {
 						CreatedOnToolsVersion = 14.1;
@@ -412,7 +412,7 @@
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_STRICT_CONCURRENCY = complete;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
@@ -445,7 +445,7 @@
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_STRICT_CONCURRENCY = complete;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;
@@ -453,7 +453,6 @@
 		2F6D13BD28F5F386007C25D6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 637867499T;
@@ -473,7 +472,6 @@
 		2F6D13BE28F5F386007C25D6 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 637867499T;

--- a/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
+++ b/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1500"
+   LastUpgradeVersion = "1620"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
# `FHIRStore` actor isolation

## :recycle: Current situation & Problem
As references in #25, the current `FHIRStore` implementation is not ideal as it still uses preconcurrency locking mechanisms. Therefore, the `FHIRStore` should be reimplemented to use Swift's structured concurrency and isolation mechanisms.


## :gear: Release Notes 
- `FHIRStore` actor isolation with structured concurrency, not relying on locks anymore.
- `FHIRResource`s are not `Sendable` anymore (underlying ModelsR4 class is not `Sendable`)

## :books: Documentation
Documented all isolation thoughts


## :white_check_mark: Testing
--


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
