### PR TITLE
Support the Parsing and Extraction of Clinical Notes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
         .package(url: "https://github.com/apple/FHIRModels", .upToNextMinor(from: "0.6.0")),
         .package(url: "https://github.com/StanfordBDHG/HealthKitOnFHIR", .upToNextMinor(from: "0.2.11")),
         .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.8.0"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziHealthKit", branch: "clinical")
+        .package(url: "https://github.com/StanfordSpezi/SpeziHealthKit", .upToNextMinor(from: "0.6.0"))
     ] + swiftLintPackage(),
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
         .package(url: "https://github.com/apple/FHIRModels", .upToNextMinor(from: "0.6.0")),
         .package(url: "https://github.com/StanfordBDHG/HealthKitOnFHIR", .upToNextMinor(from: "0.2.11")),
         .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.8.0"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziHealthKit", .upToNextMinor(from: "0.6.0"))
+        .package(url: "https://github.com/StanfordSpezi/SpeziHealthKit", branch: "clinical")
     ] + swiftLintPackage(),
     targets: [
         .target(

--- a/Sources/SpeziFHIR/FHIR.swift
+++ b/Sources/SpeziFHIR/FHIR.swift
@@ -43,11 +43,10 @@ import Spezi
 /// ```
 ///
 /// > Tip: You can learn more about how to use the store in the ``FHIRStore`` documentation.
+@available(*, deprecated, message: "We recommend using an app-specific `Standard` instead.")
 public actor FHIR: Standard {
-    @Model public private(set) var store: FHIRStore
+    @Model public private(set) var store = FHIRStore()
     
     
-    public init() {
-        self._store = Model(wrappedValue: FHIRStore())
-    }
+    public init() {}
 }

--- a/Sources/SpeziFHIR/FHIRAttachment/FHIRAttachment+DSTU2.swift
+++ b/Sources/SpeziFHIR/FHIRAttachment/FHIRAttachment+DSTU2.swift
@@ -1,7 +1,7 @@
 //
 // This source file is part of the Stanford Spezi open source project
 //
-// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
 //
 // SPDX-License-Identifier: MIT
 //
@@ -22,7 +22,11 @@ extension ModelsDSTU2.Attachment: FHIRAttachement {
     }
     
     public var mimeType: UTType? {
-        UTType(mimeType: contentType?.value?.string ?? "")
+        guard let mimeTypeString = contentType?.value?.string,
+              !mimeTypeString.isEmpty else {
+            return nil
+        }
+        return UTType(mimeType: mimeTypeString)
     }
     
     public var base64Data: String? {

--- a/Sources/SpeziFHIR/FHIRAttachment/FHIRAttachment+DSTU2.swift
+++ b/Sources/SpeziFHIR/FHIRAttachment/FHIRAttachment+DSTU2.swift
@@ -1,0 +1,40 @@
+//
+// This source file is part of the Stanford Spezi open source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import ModelsDSTU2
+import UniformTypeIdentifiers
+
+
+extension ModelsDSTU2.Attachment: FHIRAttachement {
+    public var debugDescription: String {
+        """
+        Could not transform attachement type: \(title?.primitiveDescription ?? "No title") to a string representation.
+        
+        Attachement: \(id?.primitiveDescription ?? "No ID")
+            Creation Date: \(creation?.primitiveDescription ?? "No Creation")
+            MIME Type: \(mimeType?.preferredMIMEType ?? "No Content Type")
+        """
+    }
+    
+    public var mimeType: UTType? {
+        UTType(mimeType: contentType?.value?.string ?? "")
+    }
+    
+    public var base64Data: String? {
+        get {
+            data?.value?.dataString
+        }
+        set {
+            guard let newValue else {
+                data = nil
+                return
+            }
+            data = FHIRPrimitive(ModelsDSTU2.Base64Binary(newValue))
+        }
+    }
+}

--- a/Sources/SpeziFHIR/FHIRAttachment/FHIRAttachment+R4.swift
+++ b/Sources/SpeziFHIR/FHIRAttachment/FHIRAttachment+R4.swift
@@ -1,0 +1,40 @@
+//
+// This source file is part of the Stanford Spezi open source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import ModelsR4
+import UniformTypeIdentifiers
+
+
+extension ModelsR4.Attachment: FHIRAttachement {
+    public var debugDescription: String {
+        """
+        Could not transform attachement type: \(title?.primitiveDescription ?? "No title") to a string representation.
+        
+        Attachement: \(id?.primitiveDescription ?? "No ID")
+            Creation Date: \(creation?.primitiveDescription ?? "No Creation")
+            MIME Type: \(mimeType?.preferredMIMEType ?? "No Content Type")
+        """
+    }
+
+    public var mimeType: UTType? {
+        UTType(mimeType: contentType?.value?.string ?? "")
+    }
+    
+    public var base64Data: String? {
+        get {
+            data?.value?.dataString
+        }
+        set {
+            guard let newValue else {
+                data = nil
+                return
+            }
+            data = FHIRPrimitive(ModelsR4.Base64Binary(newValue))
+        }
+    }
+}

--- a/Sources/SpeziFHIR/FHIRAttachment/FHIRAttachment+R4.swift
+++ b/Sources/SpeziFHIR/FHIRAttachment/FHIRAttachment+R4.swift
@@ -1,7 +1,7 @@
 //
 // This source file is part of the Stanford Spezi open source project
 //
-// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
 //
 // SPDX-License-Identifier: MIT
 //
@@ -22,7 +22,11 @@ extension ModelsR4.Attachment: FHIRAttachement {
     }
 
     public var mimeType: UTType? {
-        UTType(mimeType: contentType?.value?.string ?? "")
+        guard let mimeTypeString = contentType?.value?.string,
+              !mimeTypeString.isEmpty else {
+            return nil
+        }
+        return UTType(mimeType: mimeTypeString)
     }
     
     public var base64Data: String? {

--- a/Sources/SpeziFHIR/FHIRAttachment/FHIRAttachment.swift
+++ b/Sources/SpeziFHIR/FHIRAttachment/FHIRAttachment.swift
@@ -1,0 +1,64 @@
+//
+// This source file is part of the Stanford Spezi open source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import PDFKit
+import UniformTypeIdentifiers
+
+
+/// Uniform interface for FHIR attachment types.
+public protocol FHIRAttachement: AnyObject {
+    /// Debug description of the attachment
+    var debugDescription: String { get }
+    /// Best effort parsing of the MIME type of the attachment.
+    var mimeType: UTType? { get }
+    /// Convenience property to get and set the Base64 string representation of the attachment data.
+    var base64Data: String? { get set }
+}
+
+
+extension FHIRAttachement {
+    /// Best effort function to transform the base64 data representatino of an ``FHIRAttachement`` to a string-based respresentation of the data type.
+    ///
+    /// This funcationality is especially useful if the data content is inspected for debug purposes or passing it ot a LLM component.
+    public func stringifyAttachements() async throws {
+        // We inject the data right in the resource if it has the same content type.
+        // There are a few shortcomings of this appraoch:
+        // 1. We assume that the content type is a MIME type, we would need to more checks around the content.format to be fully correct.
+        // 2. The data property expects a Base64 encoded String. This is according to the FHIR spec but we don't check this in detail here.
+        guard let contentType = mimeType,
+              let base64String = base64Data,
+              let data = Data(base64Encoded: base64String) else {
+            return
+        }
+        
+        if contentType.conforms(to: .text) {
+            base64Data = String(decoding: data, as: UTF8.self)
+        } else if contentType.conforms(to: .pdf) {
+            guard let pdf = PDFDocument(data: data) else {
+                return
+            }
+            
+            let pageCount = pdf.pageCount
+            let documentContent = NSMutableAttributedString()
+            
+            for pageNumber in 0 ..< pageCount {
+                guard let page = pdf.page(at: pageNumber) else {
+                    continue
+                }
+                guard let pageContent = page.attributedString else {
+                    continue
+                }
+                documentContent.append(pageContent)
+            }
+            
+            base64Data = documentContent.string
+        } else {
+            print(debugDescription)
+        }
+    }
+}

--- a/Sources/SpeziFHIR/FHIRAttachment/FHIRResource+StringifyAttachment.swift
+++ b/Sources/SpeziFHIR/FHIRAttachment/FHIRResource+StringifyAttachment.swift
@@ -1,0 +1,34 @@
+//
+// This source file is part of the Stanford Spezi open source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import ModelsDSTU2
+import ModelsR4
+
+
+extension FHIRResource {
+    func stringifyAttachements() async throws {
+        switch versionedResource {
+        case let .r4(r4Resource):
+            guard let documentReference = r4Resource as? ModelsR4.DocumentReference else {
+                return
+            }
+            
+            for attachement in documentReference.content.compactMap(\.attachment) {
+                try await attachement.stringifyAttachements()
+            }
+        case let .dstu2(dstu2Resource):
+            guard let documentReference = dstu2Resource as? ModelsDSTU2.DocumentReference else {
+                return
+            }
+            
+            for attachement in documentReference.content.compactMap(\.attachment) {
+                try await attachement.stringifyAttachements()
+            }
+        }
+    }
+}

--- a/Sources/SpeziFHIR/FHIRAttachment/FHIRResource+StringifyAttachment.swift
+++ b/Sources/SpeziFHIR/FHIRAttachment/FHIRResource+StringifyAttachment.swift
@@ -11,7 +11,10 @@ import ModelsR4
 
 
 extension FHIRResource {
-    func stringifyAttachements() async throws {
+    /// Best effort function to transform the base64 data representatino of any ``FHIRAttachement`` to a string-based respresentation of the data type.
+    ///
+    /// This funcationality is especially useful if the data content is inspected for debug purposes or passing it ot a LLM component.
+    public func stringifyAttachements() async throws {
         switch versionedResource {
         case let .r4(r4Resource):
             guard let documentReference = r4Resource as? ModelsR4.DocumentReference else {

--- a/Sources/SpeziFHIR/FHIRAttachment/FHIRResource+StringifyAttachment.swift
+++ b/Sources/SpeziFHIR/FHIRAttachment/FHIRResource+StringifyAttachment.swift
@@ -1,7 +1,7 @@
 //
 // This source file is part of the Stanford Spezi open source project
 //
-// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
 //
 // SPDX-License-Identifier: MIT
 //
@@ -14,7 +14,7 @@ extension FHIRResource {
     /// Best effort function to transform the base64 data representatino of any ``FHIRAttachement`` to a string-based respresentation of the data type.
     ///
     /// This funcationality is especially useful if the data content is inspected for debug purposes or passing it ot a LLM component.
-    public func stringifyAttachements() async throws {
+    public func stringifyAttachements() throws {
         switch versionedResource {
         case let .r4(r4Resource):
             guard let documentReference = r4Resource as? ModelsR4.DocumentReference else {
@@ -22,7 +22,7 @@ extension FHIRResource {
             }
             
             for attachement in documentReference.content.compactMap(\.attachment) {
-                try await attachement.stringifyAttachements()
+                try attachement.stringifyAttachements()
             }
         case let .dstu2(dstu2Resource):
             guard let documentReference = dstu2Resource as? ModelsDSTU2.DocumentReference else {
@@ -30,7 +30,7 @@ extension FHIRResource {
             }
             
             for attachement in documentReference.content.compactMap(\.attachment) {
-                try await attachement.stringifyAttachements()
+                try attachement.stringifyAttachements()
             }
         }
     }

--- a/Sources/SpeziFHIR/FHIRResource/FHIRResource+Category.swift
+++ b/Sources/SpeziFHIR/FHIRResource/FHIRResource+Category.swift
@@ -15,23 +15,25 @@ import enum ModelsDSTU2.ResourceProxy
 extension FHIRResource {
     /// Enum representing different categories of FHIR resources.
     /// This categorization helps in classifying FHIR resources into common healthcare scenarios and types.
-    enum FHIRResourceCategory: CaseIterable {
-        /// Represents an observation-type resource (e.g., patient measurements, lab results).
-        case observation
-        /// Represents an encounter-type resource (e.g., patient visits, admissions).
-        case encounter
+    package enum FHIRResourceCategory: CaseIterable {
+        /// Represents an allergy or intolerance-type resource.
+        case allergyIntolerance
         ///  Represents a condition-type resource (e.g., diagnoses, patient conditions).
         case condition
         /// Represents a diagnostic-type resource (e.g., radiology, pathology reports).
         case diagnostic
-        /// Represents a procedure-type resource (e.g., surgical procedures, therapies).
-        case procedure
+        ///  Represents a document-type resource (e.g., clinical notes, discharge reports).
+        case document
+        /// Represents an encounter-type resource (e.g., patient visits, admissions).
+        case encounter
         /// Represents an immunization-type resource (e.g., vaccine administrations).
         case immunization
-        /// Represents an allergy or intolerance-type resource.
-        case allergyIntolerance
         /// Represents a medication-type resource (e.g., prescriptions, medication administrations).
         case medication
+        /// Represents an observation-type resource (e.g., patient measurements, lab results).
+        case observation
+        /// Represents a procedure-type resource (e.g., surgical procedures, therapies).
+        case procedure
         /// Represents other types of resources not covered by the above categories.
         case other
 
@@ -41,14 +43,15 @@ extension FHIRResource {
         /// - Note: Needs to be isolated on `MainActor` as the respective ``FHIRStore`` properties referred to by the `KeyPath` are isolated on the `MainActor`.
         @MainActor var storeKeyPath: KeyPath<FHIRStore, [FHIRResource]> {
             switch self {
-            case .observation: \.observations
-            case .encounter: \.encounters
-            case .condition: \.conditions
-            case .diagnostic: \.diagnostics
-            case .procedure: \.procedures
-            case .immunization: \.immunizations
             case .allergyIntolerance: \.allergyIntolerances
+            case .condition: \.conditions
+            case .encounter: \.encounters
+            case .diagnostic: \.diagnostics
+            case .document: \.documents
+            case .immunization: \.immunizations
             case .medication: \.medications
+            case .observation: \.observations
+            case .procedure: \.procedures
             case .other: \.otherResources
             }
         }
@@ -58,7 +61,7 @@ extension FHIRResource {
     /// Category of the FHIR resource.
     ///
     /// Analyzes the type of the underlying resource and assigns it to an appropriate category.
-    var category: FHIRResourceCategory {
+    package var category: FHIRResourceCategory {
         switch versionedResource {
         case let .r4(resource):
             switch ResourceProxy(with: resource) {
@@ -145,7 +148,7 @@ extension FHIRResource {
             case .documentManifest:
                 return FHIRResourceCategory.other
             case .documentReference:
-                return FHIRResourceCategory.other
+                return FHIRResourceCategory.document
             case .domainResource:
                 return FHIRResourceCategory.other
             case .effectEvidenceSynthesis:
@@ -426,7 +429,7 @@ extension FHIRResource {
             case .documentManifest:
                 return FHIRResourceCategory.other
             case .documentReference:
-                return FHIRResourceCategory.other
+                return FHIRResourceCategory.document
             case .domainResource:
                 return FHIRResourceCategory.other
             case .eligibilityRequest:

--- a/Sources/SpeziFHIR/FHIRResource/FHIRResource+Copy.swift
+++ b/Sources/SpeziFHIR/FHIRResource/FHIRResource+Copy.swift
@@ -1,7 +1,7 @@
 //
 // This source file is part of the Stanford Spezi open source project
 //
-// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
 //
 // SPDX-License-Identifier: MIT
 //
@@ -14,7 +14,7 @@ import ModelsR4
 extension FHIRResource {
     /// Creates an (expensive) copy of the underlying FHIR reference types by encoding and decoding the FHIR resource in JSON.
     ///
-    /// - Warning: The computational complexity of creating a copy should only be used in when creating a new copy is strictly nescessary.
+    /// - Warning: The computational complexity of creating a copy should only be used in when creating a new copy is strictly necessary.
     public func copy() throws -> Self {
         switch versionedResource {
         case let .r4(r4Resource):

--- a/Sources/SpeziFHIR/FHIRResource/FHIRResource+Copy.swift
+++ b/Sources/SpeziFHIR/FHIRResource/FHIRResource+Copy.swift
@@ -1,8 +1,9 @@
 //
-//  File.swift
-//  SpeziFHIR
+// This source file is part of the Stanford Spezi open source project
 //
-//  Created by Paul Schmiedmayer on 3/8/25.
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
 //
 
 import Foundation

--- a/Sources/SpeziFHIR/FHIRResource/FHIRResource+Copy.swift
+++ b/Sources/SpeziFHIR/FHIRResource/FHIRResource+Copy.swift
@@ -1,0 +1,27 @@
+//
+//  File.swift
+//  SpeziFHIR
+//
+//  Created by Paul Schmiedmayer on 3/8/25.
+//
+
+import Foundation
+import ModelsDSTU2
+import ModelsR4
+
+
+extension FHIRResource {
+    /// Creates an (expensive) copy of the underlying FHIR reference types by encoding and decoding the FHIR resource in JSON.
+    ///
+    /// - Warning: The computational complexity of creating a copy should only be used in when creating a new copy is strictly nescessary.
+    public func copy() throws -> Self {
+        switch versionedResource {
+        case let .r4(r4Resource):
+            let resource = try JSONDecoder().decode(ModelsR4.ResourceProxy.self, from: try JSONEncoder().encode(r4Resource)).get()
+            return .init(resource: resource, displayName: displayName)
+        case let .dstu2(dstu2Resource):
+            let resource = try JSONDecoder().decode(ModelsDSTU2.ResourceProxy.self, from: try JSONEncoder().encode(dstu2Resource)).get()
+            return .init(resource: resource, displayName: displayName)
+        }
+    }
+}

--- a/Sources/SpeziFHIR/FHIRStore.swift
+++ b/Sources/SpeziFHIR/FHIRStore.swift
@@ -46,6 +46,12 @@ public final class FHIRStore: Module,
         access(keyPath: \.diagnostics)
         return _resources.filter { $0.category == .diagnostic }
     }
+    
+    /// `FHIRResource`s with category `documentReference`.
+    @MainActor public var documents: [FHIRResource] {
+        access(keyPath: \.documents)
+        return _resources.filter { $0.category == .document }
+    }
 
     /// `FHIRResource`s with category `encounter`.
     @MainActor public var encounters: [FHIRResource] {
@@ -75,12 +81,6 @@ public final class FHIRStore: Module,
     @MainActor public var procedures: [FHIRResource] {
         access(keyPath: \.procedures)
         return _resources.filter { $0.category == .procedure }
-    }
-    
-    /// `FHIRResource`s with category `documentReference`.
-    @MainActor public var documents: [FHIRResource] {
-        access(keyPath: \.documents)
-        return _resources.filter { $0.category == .document }
     }
 
     /// `FHIRResource`s with category `other`.

--- a/Sources/SpeziFHIR/FHIRStore.swift
+++ b/Sources/SpeziFHIR/FHIRStore.swift
@@ -76,6 +76,12 @@ public final class FHIRStore: Module,
         access(keyPath: \.procedures)
         return _resources.filter { $0.category == .procedure }
     }
+    
+    /// `FHIRResource`s with category `documentReference`.
+    @MainActor public var documents: [FHIRResource] {
+        access(keyPath: \.documents)
+        return _resources.filter { $0.category == .document }
+    }
 
     /// `FHIRResource`s with category `other`.
     @MainActor public var otherResources: [FHIRResource] {

--- a/Sources/SpeziFHIRHealthKit/FHIRResource+HealthKit.swift
+++ b/Sources/SpeziFHIRHealthKit/FHIRResource+HealthKit.swift
@@ -1,0 +1,71 @@
+//
+// This source file is part of the Stanford Spezi open source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+@preconcurrency import HealthKit
+import HealthKitOnFHIR
+import ModelsDSTU2
+import ModelsR4
+import SpeziFHIR
+
+
+extension FHIRResource {
+    /// Creates a new ``FHIRResource`` instance using an `HKSample`.
+    /// - Parameters:
+    ///   - sample: The sample that should be transformed in a ``FHIRResource``.
+    ///   - hkHealthStore: Optional `HKHealthStore` used to query additional context such as symptoms and voltage measurements for electrocardiograms. Set to nil to avoid this behavior.
+    /// - Returns: Created ``FHIRResource`` instance.
+     public static func initialize(
+        basedOn sample: HKSample,
+        hkHealthStore: HKHealthStore? = HKHealthStore()
+    ) async throws -> FHIRResource {
+        switch sample {
+        case let clinicalResource as HKClinicalRecord where clinicalResource.fhirResource?.fhirVersion == .primaryDSTU2():
+            guard let fhirResource = clinicalResource.fhirResource else {
+                throw HealthKitOnFHIRError.invalidFHIRResource
+            }
+            
+            let decoder = JSONDecoder()
+            let resourceProxy = try decoder.decode(ModelsDSTU2.ResourceProxy.self, from: fhirResource.data)
+            let fhirModelResource = resourceProxy.get()
+            
+            return FHIRResource(
+                versionedResource: .dstu2(fhirModelResource),
+                displayName: clinicalResource.displayName
+            )
+        case let clinicalResource as HKClinicalRecord:
+            let fhirModelResource = try clinicalResource.resource.get()
+            
+            return FHIRResource(
+                versionedResource: .r4(fhirModelResource),
+                displayName: clinicalResource.displayName
+            )
+        case let electrocardiogram as HKElectrocardiogram:
+            guard let hkHealthStore = hkHealthStore else {
+                fallthrough
+            }
+            
+            async let symptoms = try electrocardiogram.symptoms(from: hkHealthStore)
+            async let voltageMeasurements = try electrocardiogram.voltageMeasurements(from: hkHealthStore)
+            
+            let electrocardiogramResource = try await electrocardiogram.observation(
+                symptoms: symptoms,
+                voltageMeasurements: voltageMeasurements
+            )
+            return FHIRResource(
+                versionedResource: .r4(electrocardiogramResource),
+                displayName: String(localized: "FHIR_RESOURCES_SUMMARY_ID_TITLE \(electrocardiogramResource.id?.value?.string ?? "-")")
+            )
+        default:
+            let genericResource = try sample.resource.get()
+            return FHIRResource(
+                versionedResource: .r4(genericResource),
+                displayName: String(localized: "FHIR_RESOURCES_SUMMARY_ID_TITLE \(genericResource.id?.value?.string ?? "-")")
+            )
+        }
+    }
+}

--- a/Sources/SpeziFHIRHealthKit/FHIRResource+HealthKit.swift
+++ b/Sources/SpeziFHIRHealthKit/FHIRResource+HealthKit.swift
@@ -1,7 +1,7 @@
 //
 // This source file is part of the Stanford Spezi open source project
 //
-// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
 //
 // SPDX-License-Identifier: MIT
 //

--- a/Sources/SpeziFHIRHealthKit/FHIRResource+LoadAttachements.swift
+++ b/Sources/SpeziFHIRHealthKit/FHIRResource+LoadAttachements.swift
@@ -1,0 +1,123 @@
+//
+// This source file is part of the Stanford Spezi open source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+@preconcurrency import HealthKit
+import ModelsDSTU2
+import ModelsR4
+import PDFKit
+import SpeziFHIR
+
+
+extension FHIRResource {
+    mutating func loadAttachements(from healthKitSample: HKSample, store: HKHealthStore = HKHealthStore()) async throws {
+        guard category == .document else {
+            return
+        }
+        
+        // We inject the data right in the resource if it has the same content type.
+        // There are a few shortcomings of this appraoch:
+        // 1. We assume that the content type is a MIME type, we would need to more checks around the content.format to be fully correct.
+        // 2. The data property actually expects a Base64 encoded String. We currently just inject a normal string.
+        // Otherwise we create a new content entry to inject this information in here.
+        switch versionedResource {
+        case let .r4(r4Resource):
+            guard let documentReference = r4Resource as? ModelsR4.DocumentReference else {
+                print("Unexpected FHIR type in the document parsing path: \(r4Resource.description)")
+                return
+            }
+            
+            for textEncodedAttachement in try await textEncodedAttachements(for: healthKitSample, hkHealthStore: store) {
+                let data = FHIRPrimitive(ModelsR4.Base64Binary(textEncodedAttachement.content))
+                if let content = documentReference.content.first(
+                       where: { $0.attachment.contentType?.value?.string == textEncodedAttachement.identifier }
+                   ),
+                   content.attachment.data == nil {
+                    content.attachment.data = data
+                } else {
+                    documentReference.content.append(
+                        DocumentReferenceContent(
+                            attachment: Attachment(contentType: FHIRPrimitive(stringLiteral: textEncodedAttachement.identifier), data: data)
+                        )
+                    )
+                }
+            }
+        case let .dstu2(dstu2Resource):
+            guard let documentReference = dstu2Resource as? ModelsDSTU2.DocumentReference else {
+                print("Unexpected FHIR type in the document parsing path: \(dstu2Resource.description)")
+                return
+            }
+            
+            for textEncodedAttachement in try await textEncodedAttachements(for: healthKitSample, hkHealthStore: store) {
+                let data = FHIRPrimitive(ModelsDSTU2.Base64Binary(textEncodedAttachement.content))
+                if let content = documentReference.content.first(
+                       where: { $0.attachment.contentType?.value?.string == textEncodedAttachement.identifier }
+                   ),
+                   content.attachment.data == nil {
+                    content.attachment.data = data
+                } else {
+                    documentReference.content.append(
+                        DocumentReferenceContent(
+                            attachment: Attachment(contentType: FHIRPrimitive(stringLiteral: textEncodedAttachement.identifier), data: data)
+                        )
+                    )
+                }
+            }
+        }
+    }
+    
+    private func textEncodedAttachements(
+        for healthKitSample: HKSample,
+        hkHealthStore: HKHealthStore = HKHealthStore()
+    ) async throws -> [(identifier: String, content: String)] {
+        let attachmentStore = HKAttachmentStore(healthStore: hkHealthStore)
+        let attachments = try await attachmentStore.attachments(for: healthKitSample)
+        
+        var strings: [(identifier: String, content: String)] = []
+        
+        for attachment in attachments {
+            let dataReader = attachmentStore.dataReader(for: attachment)
+            let mimeType = attachment.contentType.preferredMIMEType ?? attachment.contentType.identifier
+            if attachment.contentType.conforms(to: .text) {
+                let data = try await dataReader.data
+                strings.append((mimeType, String(decoding: data, as: UTF8.self)))
+            } else if attachment.contentType.conforms(to: .pdf) {
+                let data = try await dataReader.data
+                if let pdf = PDFDocument(data: data) {
+                    let pageCount = pdf.pageCount
+                    let documentContent = NSMutableAttributedString()
+
+                    for pageNumber in 0 ..< pageCount {
+                        guard let page = pdf.page(at: pageNumber) else {
+                            continue
+                        }
+                        guard let pageContent = page.attributedString else {
+                            continue
+                        }
+                        documentContent.append(pageContent)
+                    }
+                    
+                    strings.append((mimeType, documentContent.string))
+                }
+            } else {
+                print(
+                    """
+                    Could not transform attachement type: \(attachment.contentType) to a string representation.
+                    
+                    Attachement: \(attachment.identifier)
+                        Name: \(attachment.name)
+                        Creation Date: \(attachment.creationDate)
+                        Size: \(attachment.size)
+                        Content Type: \(attachment.contentType)
+                    """
+                )
+            }
+        }
+        
+        return strings
+    }
+}

--- a/Sources/SpeziFHIRHealthKit/FHIRResource+LoadAttachements.swift
+++ b/Sources/SpeziFHIRHealthKit/FHIRResource+LoadAttachements.swift
@@ -1,7 +1,7 @@
 //
 // This source file is part of the Stanford Spezi open source project
 //
-// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
 //
 // SPDX-License-Identifier: MIT
 //

--- a/Sources/SpeziFHIRHealthKit/FHIRStore+HealthKit.swift
+++ b/Sources/SpeziFHIRHealthKit/FHIRStore+HealthKit.swift
@@ -10,11 +10,15 @@
 import HealthKitOnFHIR
 import ModelsDSTU2
 import ModelsR4
+import PDFKit
 import SpeziFHIR
 import SpeziHealthKit
 
 
 extension FHIRStore {
+    /// Indicates if the FHIR store should load attachement documents from clinical health record data when transform HKSamples to FHIR documents.
+    @MainActor public static var loadHealthKitAttachements: Bool = false
+    
     private static let hkHealthStore: HKHealthStore? = {
         guard HKHealthStore.isHealthDataAvailable() else {
             return nil
@@ -28,7 +32,10 @@ extension FHIRStore {
     /// - Parameter sample: The sample that should be added.
     public func add(sample: HKSample) async {
         do {
-            let resource = try await transform(sample: sample)
+            var resource = try await transform(sample: sample)
+            if await Self.loadHealthKitAttachements, let hkHealthStore = Self.hkHealthStore {
+                try await resource.loadAttachements(from: sample, store: hkHealthStore)
+            }
             await insert(resource: resource)
         } catch {
             print("Could not transform HKSample: \(error)")
@@ -51,9 +58,17 @@ extension FHIRStore {
             
             let decoder = JSONDecoder()
             let resourceProxy = try decoder.decode(ModelsDSTU2.ResourceProxy.self, from: fhirResource.data)
+            let fhirModelResource = resourceProxy.get()
             
             return FHIRResource(
-                versionedResource: .dstu2(resourceProxy.get()),
+                versionedResource: .dstu2(fhirModelResource),
+                displayName: clinicalResource.displayName
+            )
+        case let clinicalResource as HKClinicalRecord:
+            let fhirModelResource = try clinicalResource.resource.get()
+            
+            return FHIRResource(
+                versionedResource: .r4(fhirModelResource),
                 displayName: clinicalResource.displayName
             )
         case let electrocardiogram as HKElectrocardiogram:
@@ -79,5 +94,117 @@ extension FHIRStore {
                 displayName: String(localized: "FHIR_RESOURCES_SUMMARY_ID_TITLE \(genericResource.id?.value?.string ?? "-")")
             )
         }
+    }
+}
+
+extension FHIRResource {
+    mutating func loadAttachements(from healthKitSample: HKSample, store: HKHealthStore = HKHealthStore()) async throws {
+        guard category == .document else {
+            return
+        }
+        
+        // We inject the data right in the resource if it has the same content type.
+        // There are a few shortcomings of this appraoch:
+        // 1. We assume that the content type is a MIME type, we would need to more checks around the content.format to be fully correct.
+        // 2. The data property actually expects a Base64 encoded String. We currently just inject a normal string.
+        // Otherwise we create a new content entry to inject this information in here.
+        switch versionedResource {
+        case let .r4(r4Resource):
+            guard let documentReference = r4Resource as? ModelsR4.DocumentReference else {
+                print("Unexpected FHIR type in the document parsing path: \(r4Resource.description)")
+                return
+            }
+            
+            for textEncodedAttachement in try await textEncodedAttachements(for: healthKitSample, hkHealthStore: store) {
+                let data = FHIRPrimitive(ModelsR4.Base64Binary(textEncodedAttachement.content))
+                if let content = documentReference.content.first(
+                       where: { $0.attachment.contentType?.value?.string == textEncodedAttachement.identifier }
+                   ),
+                   content.attachment.data == nil {
+                    content.attachment.data = data
+                } else {
+                    documentReference.content.append(
+                        DocumentReferenceContent(
+                            attachment: Attachment(contentType: FHIRPrimitive(stringLiteral: textEncodedAttachement.identifier), data: data)
+                        )
+                    )
+                }
+            }
+        case let .dstu2(dstu2Resource):
+            guard let documentReference = dstu2Resource as? ModelsDSTU2.DocumentReference else {
+                print("Unexpected FHIR type in the document parsing path: \(dstu2Resource.description)")
+                return
+            }
+            
+            for textEncodedAttachement in try await textEncodedAttachements(for: healthKitSample, hkHealthStore: store) {
+                let data = FHIRPrimitive(ModelsDSTU2.Base64Binary(textEncodedAttachement.content))
+                if let content = documentReference.content.first(
+                       where: { $0.attachment.contentType?.value?.string == textEncodedAttachement.identifier }
+                   ),
+                   content.attachment.data == nil {
+                    content.attachment.data = data
+                } else {
+                    documentReference.content.append(
+                        DocumentReferenceContent(
+                            attachment: Attachment(contentType: FHIRPrimitive(stringLiteral: textEncodedAttachement.identifier), data: data)
+                        )
+                    )
+                }
+            }
+        }
+    }
+    
+    private func textEncodedAttachements(
+        for healthKitSample: HKSample,
+        hkHealthStore: HKHealthStore = HKHealthStore()
+    ) async throws -> [(identifier: String, content: String)] {
+        let attachmentStore = HKAttachmentStore(healthStore: hkHealthStore)
+        let attachments = try await attachmentStore.attachments(for: healthKitSample)
+        
+        var strings: [(identifier: String, content: String)] = []
+        
+        for attachment in attachments {
+            let dataReader = attachmentStore.dataReader(for: attachment)
+            let mimeType = attachment.contentType.preferredMIMEType ?? attachment.contentType.identifier
+            
+            if attachment.contentType.conforms(to: .text) {
+                let data = try await dataReader.data
+                strings.append((mimeType, String(decoding: data, as: UTF8.self)))
+            }
+            
+            if attachment.contentType.conforms(to: .pdf) {
+                let data = try await dataReader.data
+                if let pdf = PDFDocument(data: data) {
+                    let pageCount = pdf.pageCount
+                    let documentContent = NSMutableAttributedString()
+
+                    for pageNumber in 0 ..< pageCount {
+                        guard let page = pdf.page(at: pageNumber) else {
+                            continue
+                        }
+                        guard let pageContent = page.attributedString else {
+                            continue
+                        }
+                        documentContent.append(pageContent)
+                    }
+                    
+                    strings.append((mimeType, documentContent.string))
+                }
+            }
+            
+            print(
+                """
+                Could not transform attachement type: \(attachment.contentType) to a string representation.
+                
+                Attachement: \(attachment.identifier)
+                    Name: \(attachment.name)
+                    Creation Date: \(attachment.creationDate)
+                    Size: \(attachment.size)
+                    Content Type: \(attachment.contentType)
+                """
+            )
+        }
+        
+        return strings
     }
 }

--- a/Sources/SpeziFHIRHealthKit/FHIRStore+HealthKit.swift
+++ b/Sources/SpeziFHIRHealthKit/FHIRStore+HealthKit.swift
@@ -28,7 +28,10 @@ extension FHIRStore {
     /// - Parameters:
     ///   - sample: The sample that should be added.
     ///   - loadHealthKitAttachements: Indicates if the `HKAttachmentStore` should be queried for any document references found in clinical records.
-    public func add(sample: HKSample, loadHealthKitAttachements: Bool = false) async {
+    public func add(
+        sample: HKSample,
+        loadHealthKitAttachements: Bool = false
+    ) async {
         do {
             var resource = try await FHIRResource.initialize(basedOn: sample)
             if loadHealthKitAttachements, let hkHealthStore = Self.hkHealthStore {

--- a/Sources/SpeziFHIRHealthKit/FHIRStore+HealthKit.swift
+++ b/Sources/SpeziFHIRHealthKit/FHIRStore+HealthKit.swift
@@ -10,15 +10,11 @@
 import HealthKitOnFHIR
 import ModelsDSTU2
 import ModelsR4
-import PDFKit
 import SpeziFHIR
 import SpeziHealthKit
 
 
 extension FHIRStore {
-    /// Indicates if the FHIR store should load attachement documents from clinical health record data when transform HKSamples to FHIR documents.
-    @MainActor public static var loadHealthKitAttachements: Bool = false
-    
     private static let hkHealthStore: HKHealthStore? = {
         guard HKHealthStore.isHealthDataAvailable() else {
             return nil
@@ -29,11 +25,13 @@ extension FHIRStore {
     
     
     /// Add a HealthKit sample to the FHIR store.
-    /// - Parameter sample: The sample that should be added.
-    public func add(sample: HKSample) async {
+    /// - Parameters:
+    ///   - sample: The sample that should be added.
+    ///   - loadHealthKitAttachements: Indicates if the `HKAttachmentStore` should be queried for any document references found in clinical records.
+    public func add(sample: HKSample, loadHealthKitAttachements: Bool = false) async {
         do {
-            var resource = try await transform(sample: sample)
-            if await Self.loadHealthKitAttachements, let hkHealthStore = Self.hkHealthStore {
+            var resource = try await FHIRResource.initialize(basedOn: sample)
+            if loadHealthKitAttachements, let hkHealthStore = Self.hkHealthStore {
                 try await resource.loadAttachements(from: sample, store: hkHealthStore)
             }
             await insert(resource: resource)
@@ -46,163 +44,5 @@ extension FHIRStore {
     /// - Parameter sample: The sample delete object that should be removed.
     public func remove(sample: HKDeletedObject) async {
         await remove(resource: sample.uuid.uuidString)
-    }
-    
-    
-    private func transform(sample: HKSample) async throws -> FHIRResource {
-        switch sample {
-        case let clinicalResource as HKClinicalRecord where clinicalResource.fhirResource?.fhirVersion == .primaryDSTU2():
-            guard let fhirResource = clinicalResource.fhirResource else {
-                throw HealthKitOnFHIRError.invalidFHIRResource
-            }
-            
-            let decoder = JSONDecoder()
-            let resourceProxy = try decoder.decode(ModelsDSTU2.ResourceProxy.self, from: fhirResource.data)
-            let fhirModelResource = resourceProxy.get()
-            
-            return FHIRResource(
-                versionedResource: .dstu2(fhirModelResource),
-                displayName: clinicalResource.displayName
-            )
-        case let clinicalResource as HKClinicalRecord:
-            let fhirModelResource = try clinicalResource.resource.get()
-            
-            return FHIRResource(
-                versionedResource: .r4(fhirModelResource),
-                displayName: clinicalResource.displayName
-            )
-        case let electrocardiogram as HKElectrocardiogram:
-            guard let hkHealthStore = Self.hkHealthStore else {
-                fallthrough
-            }
-            
-            async let symptoms = try electrocardiogram.symptoms(from: hkHealthStore)
-            async let voltageMeasurements = try electrocardiogram.voltageMeasurements(from: hkHealthStore)
-            
-            let electrocardiogramResource = try await electrocardiogram.observation(
-                symptoms: symptoms,
-                voltageMeasurements: voltageMeasurements
-            )
-            return FHIRResource(
-                versionedResource: .r4(electrocardiogramResource),
-                displayName: String(localized: "FHIR_RESOURCES_SUMMARY_ID_TITLE \(electrocardiogramResource.id?.value?.string ?? "-")")
-            )
-        default:
-            let genericResource = try sample.resource.get()
-            return FHIRResource(
-                versionedResource: .r4(genericResource),
-                displayName: String(localized: "FHIR_RESOURCES_SUMMARY_ID_TITLE \(genericResource.id?.value?.string ?? "-")")
-            )
-        }
-    }
-}
-
-extension FHIRResource {
-    mutating func loadAttachements(from healthKitSample: HKSample, store: HKHealthStore = HKHealthStore()) async throws {
-        guard category == .document else {
-            return
-        }
-        
-        // We inject the data right in the resource if it has the same content type.
-        // There are a few shortcomings of this appraoch:
-        // 1. We assume that the content type is a MIME type, we would need to more checks around the content.format to be fully correct.
-        // 2. The data property actually expects a Base64 encoded String. We currently just inject a normal string.
-        // Otherwise we create a new content entry to inject this information in here.
-        switch versionedResource {
-        case let .r4(r4Resource):
-            guard let documentReference = r4Resource as? ModelsR4.DocumentReference else {
-                print("Unexpected FHIR type in the document parsing path: \(r4Resource.description)")
-                return
-            }
-            
-            for textEncodedAttachement in try await textEncodedAttachements(for: healthKitSample, hkHealthStore: store) {
-                let data = FHIRPrimitive(ModelsR4.Base64Binary(textEncodedAttachement.content))
-                if let content = documentReference.content.first(
-                       where: { $0.attachment.contentType?.value?.string == textEncodedAttachement.identifier }
-                   ),
-                   content.attachment.data == nil {
-                    content.attachment.data = data
-                } else {
-                    documentReference.content.append(
-                        DocumentReferenceContent(
-                            attachment: Attachment(contentType: FHIRPrimitive(stringLiteral: textEncodedAttachement.identifier), data: data)
-                        )
-                    )
-                }
-            }
-        case let .dstu2(dstu2Resource):
-            guard let documentReference = dstu2Resource as? ModelsDSTU2.DocumentReference else {
-                print("Unexpected FHIR type in the document parsing path: \(dstu2Resource.description)")
-                return
-            }
-            
-            for textEncodedAttachement in try await textEncodedAttachements(for: healthKitSample, hkHealthStore: store) {
-                let data = FHIRPrimitive(ModelsDSTU2.Base64Binary(textEncodedAttachement.content))
-                if let content = documentReference.content.first(
-                       where: { $0.attachment.contentType?.value?.string == textEncodedAttachement.identifier }
-                   ),
-                   content.attachment.data == nil {
-                    content.attachment.data = data
-                } else {
-                    documentReference.content.append(
-                        DocumentReferenceContent(
-                            attachment: Attachment(contentType: FHIRPrimitive(stringLiteral: textEncodedAttachement.identifier), data: data)
-                        )
-                    )
-                }
-            }
-        }
-    }
-    
-    private func textEncodedAttachements(
-        for healthKitSample: HKSample,
-        hkHealthStore: HKHealthStore = HKHealthStore()
-    ) async throws -> [(identifier: String, content: String)] {
-        let attachmentStore = HKAttachmentStore(healthStore: hkHealthStore)
-        let attachments = try await attachmentStore.attachments(for: healthKitSample)
-        
-        var strings: [(identifier: String, content: String)] = []
-        
-        for attachment in attachments {
-            let dataReader = attachmentStore.dataReader(for: attachment)
-            let mimeType = attachment.contentType.preferredMIMEType ?? attachment.contentType.identifier
-            
-            if attachment.contentType.conforms(to: .text) {
-                let data = try await dataReader.data
-                strings.append((mimeType, String(decoding: data, as: UTF8.self)))
-            } else if attachment.contentType.conforms(to: .pdf) {
-                let data = try await dataReader.data
-                if let pdf = PDFDocument(data: data) {
-                    let pageCount = pdf.pageCount
-                    let documentContent = NSMutableAttributedString()
-
-                    for pageNumber in 0 ..< pageCount {
-                        guard let page = pdf.page(at: pageNumber) else {
-                            continue
-                        }
-                        guard let pageContent = page.attributedString else {
-                            continue
-                        }
-                        documentContent.append(pageContent)
-                    }
-                    
-                    strings.append((mimeType, documentContent.string))
-                }
-            } else {
-                print(
-                    """
-                    Could not transform attachement type: \(attachment.contentType) to a string representation.
-                    
-                    Attachement: \(attachment.identifier)
-                        Name: \(attachment.name)
-                        Creation Date: \(attachment.creationDate)
-                        Size: \(attachment.size)
-                        Content Type: \(attachment.contentType)
-                    """
-                )
-            }
-        }
-        
-        return strings
     }
 }

--- a/Sources/SpeziFHIRHealthKit/FHIRStore+HealthKit.swift
+++ b/Sources/SpeziFHIRHealthKit/FHIRStore+HealthKit.swift
@@ -170,9 +170,7 @@ extension FHIRResource {
             if attachment.contentType.conforms(to: .text) {
                 let data = try await dataReader.data
                 strings.append((mimeType, String(decoding: data, as: UTF8.self)))
-            }
-            
-            if attachment.contentType.conforms(to: .pdf) {
+            } else if attachment.contentType.conforms(to: .pdf) {
                 let data = try await dataReader.data
                 if let pdf = PDFDocument(data: data) {
                     let pageCount = pdf.pageCount
@@ -190,19 +188,19 @@ extension FHIRResource {
                     
                     strings.append((mimeType, documentContent.string))
                 }
+            } else {
+                print(
+                    """
+                    Could not transform attachement type: \(attachment.contentType) to a string representation.
+                    
+                    Attachement: \(attachment.identifier)
+                        Name: \(attachment.name)
+                        Creation Date: \(attachment.creationDate)
+                        Size: \(attachment.size)
+                        Content Type: \(attachment.contentType)
+                    """
+                )
             }
-            
-            print(
-                """
-                Could not transform attachement type: \(attachment.contentType) to a string representation.
-                
-                Attachement: \(attachment.identifier)
-                    Name: \(attachment.name)
-                    Creation Date: \(attachment.creationDate)
-                    Size: \(attachment.size)
-                    Content Type: \(attachment.contentType)
-                """
-            )
         }
         
         return strings

--- a/Sources/SpeziFHIRHealthKit/FHIRStore+HealthKit.swift
+++ b/Sources/SpeziFHIRHealthKit/FHIRStore+HealthKit.swift
@@ -1,7 +1,7 @@
 //
 // This source file is part of the Stanford Spezi open source project
 //
-// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
 //
 // SPDX-License-Identifier: MIT
 //

--- a/Tests/UITests/TestApp/ContentView.swift
+++ b/Tests/UITests/TestApp/ContentView.swift
@@ -30,6 +30,7 @@ struct ContentView: View {
                     Text("Allergy Intolerances: \(fhirStore.allergyIntolerances.count)")
                     Text("Conditions: \(fhirStore.conditions.count)")
                     Text("Diagnostics: \(fhirStore.diagnostics.count)")
+                    Text("Documents: \(fhirStore.documents.count)")
                     Text("Encounters: \(fhirStore.encounters.count)")
                     Text("Immunizations: \(fhirStore.immunizations.count)")
                     Text("Medications: \(fhirStore.medications.count)")

--- a/Tests/UITests/TestApp/ContentView.swift
+++ b/Tests/UITests/TestApp/ContentView.swift
@@ -84,7 +84,7 @@ struct ContentView: View {
     }
     
     @ViewBuilder private var collectFromHealthKitButton: some View {
-        AsyncButton("Ask for authorization", state: $viewState) {
+        AsyncButton("Load HealthKit Clinical Records", state: $viewState) {
             try await healthKit.askForAuthorization()
             await standard.loadHealthKitResources()
         }

--- a/Tests/UITests/TestApp/TestApp.entitlements
+++ b/Tests/UITests/TestApp/TestApp.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.healthkit</key>
+	<true/>
+	<key>com.apple.developer.healthkit.access</key>
+	<array>
+		<string>health-records</string>
+	</array>
+</dict>
+</plist>

--- a/Tests/UITests/TestApp/TestApp.entitlements.license
+++ b/Tests/UITests/TestApp/TestApp.entitlements.license
@@ -1,0 +1,5 @@
+This source file is part of the Stanford Spezi open-source project
+
+SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+
+SPDX-License-Identifier: MIT

--- a/Tests/UITests/TestApp/TestAppDelegate.swift
+++ b/Tests/UITests/TestApp/TestAppDelegate.swift
@@ -21,18 +21,22 @@ class TestAppDelegate: SpeziAppDelegate {
         )
     }
     
+    private var deliverySetting: HealthKitDeliverySetting {
+        .anchorQuery(saveAnchor: false)
+    }
+    
     override var configuration: Configuration {
         Configuration(standard: TestingStandard()) {
             HealthKit {
-                CollectSample(.allergyRecord, predicate: healthKitPredicate)
-                CollectSample(.clinicalNoteRecord, predicate: healthKitPredicate)
-                CollectSample(.conditionRecord, predicate: healthKitPredicate)
-                CollectSample(.coverageRecord, predicate: healthKitPredicate)
-                CollectSample(.immunizationRecord, predicate: healthKitPredicate)
-                CollectSample(.labResultRecord, predicate: healthKitPredicate)
-                CollectSample(.medicationRecord, predicate: healthKitPredicate)
-                CollectSample(.procedureRecord, predicate: healthKitPredicate)
-                CollectSample(.vitalSignRecord, predicate: healthKitPredicate)
+                CollectSample(HKClinicalType(.allergyRecord), predicate: healthKitPredicate, deliverySetting: deliverySetting)
+                CollectSample(HKClinicalType(.clinicalNoteRecord), predicate: healthKitPredicate, deliverySetting: deliverySetting)
+                CollectSample(HKClinicalType(.conditionRecord), predicate: healthKitPredicate, deliverySetting: deliverySetting)
+                CollectSample(HKClinicalType(.coverageRecord), predicate: healthKitPredicate, deliverySetting: deliverySetting)
+                CollectSample(HKClinicalType(.immunizationRecord), predicate: healthKitPredicate, deliverySetting: deliverySetting)
+                CollectSample(HKClinicalType(.labResultRecord), predicate: healthKitPredicate, deliverySetting: deliverySetting)
+                CollectSample(HKClinicalType(.medicationRecord), predicate: healthKitPredicate, deliverySetting: deliverySetting)
+                CollectSample(HKClinicalType(.procedureRecord), predicate: healthKitPredicate, deliverySetting: deliverySetting)
+                CollectSample(HKClinicalType(.vitalSignRecord), predicate: healthKitPredicate, deliverySetting: deliverySetting)
             }
         }
     }

--- a/Tests/UITests/TestApp/TestAppDelegate.swift
+++ b/Tests/UITests/TestApp/TestAppDelegate.swift
@@ -8,11 +8,32 @@
 
 import Spezi
 import SpeziFHIR
+import SpeziHealthKit
 import SwiftUI
 
 
 class TestAppDelegate: SpeziAppDelegate {
+    private var healthKitPredicate: NSPredicate {
+        HKQuery.predicateForSamples(
+            withStart: Date.distantPast,
+            end: nil,
+            options: .strictEndDate
+        )
+    }
+    
     override var configuration: Configuration {
-        Configuration(standard: FHIR()) { }
+        Configuration(standard: TestingStandard()) {
+            HealthKit {
+                CollectSample(.allergyRecord, predicate: healthKitPredicate)
+                CollectSample(.clinicalNoteRecord, predicate: healthKitPredicate)
+                CollectSample(.conditionRecord, predicate: healthKitPredicate)
+                CollectSample(.coverageRecord, predicate: healthKitPredicate)
+                CollectSample(.immunizationRecord, predicate: healthKitPredicate)
+                CollectSample(.labResultRecord, predicate: healthKitPredicate)
+                CollectSample(.medicationRecord, predicate: healthKitPredicate)
+                CollectSample(.procedureRecord, predicate: healthKitPredicate)
+                CollectSample(.vitalSignRecord, predicate: healthKitPredicate)
+            }
+        }
     }
 }

--- a/Tests/UITests/TestApp/TestingStandard.swift
+++ b/Tests/UITests/TestApp/TestingStandard.swift
@@ -34,13 +34,10 @@ actor TestingStandard: Standard, HealthKitConstraint, EnvironmentAccessible {
     }
     
     func loadHealthKitResources() async {
-        await MainActor.run {
-            FHIRStore.loadHealthKitAttachements = true
-        }
         await fhirStore.removeAllResources()
         
         for sample in samples {
-            await fhirStore.add(sample: sample)
+            await fhirStore.add(sample: sample, loadHealthKitAttachements: true)
         }
         
         useHealthKitResources = true

--- a/Tests/UITests/TestApp/TestingStandard.swift
+++ b/Tests/UITests/TestApp/TestingStandard.swift
@@ -34,6 +34,9 @@ actor TestingStandard: Standard, HealthKitConstraint, EnvironmentAccessible {
     }
     
     func loadHealthKitResources() async {
+        await MainActor.run {
+            FHIRStore.loadHealthKitAttachements = true
+        }
         await fhirStore.removeAllResources()
         
         for sample in samples {

--- a/Tests/UITests/TestApp/TestingStandard.swift
+++ b/Tests/UITests/TestApp/TestingStandard.swift
@@ -1,0 +1,45 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Spezi
+import SpeziFHIR
+import SpeziFHIRHealthKit
+import SpeziHealthKit
+
+
+actor TestingStandard: Standard, HealthKitConstraint, EnvironmentAccessible {
+    @Model private(set) var fhirStore = FHIRStore()
+    
+    private var useHealthKitResources = true
+    private var samples: [HKSample] = []
+    
+    
+    func add(sample: HKSample) async {
+        samples.append(sample)
+        if useHealthKitResources {
+            await fhirStore.add(sample: sample)
+        }
+    }
+    
+    func remove(sample: HKDeletedObject) async {
+        samples.removeAll(where: { $0.id == sample.uuid })
+        if useHealthKitResources {
+            await fhirStore.remove(sample: sample)
+        }
+    }
+    
+    func loadHealthKitResources() async {
+        await fhirStore.removeAllResources()
+        
+        for sample in samples {
+            await fhirStore.add(sample: sample)
+        }
+        
+        useHealthKitResources = true
+    }
+}

--- a/Tests/UITests/TestAppUITests/FHIRMockDataStorageProviderTests.swift
+++ b/Tests/UITests/TestAppUITests/FHIRMockDataStorageProviderTests.swift
@@ -17,6 +17,7 @@ final class SpeziFHIRTests: XCTestCase {
         XCTAssert(app.staticTexts["Allergy Intolerances: 0"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Conditions: 0"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Diagnostics: 0"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Documents: 0"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Encounters: 0"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Immunizations: 0"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Medications: 0"].waitForExistence(timeout: 2))
@@ -35,12 +36,13 @@ final class SpeziFHIRTests: XCTestCase {
         XCTAssert(app.staticTexts["Allergy Intolerances: 0"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Conditions: 70"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Diagnostics: 205"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Documents: 82"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Encounters: 82"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Immunizations: 12"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Medications: 31"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Observations: 769"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Procedures: 106"].waitForExistence(timeout: 2))
-        XCTAssert(app.staticTexts["Other Resources: 302"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Other Resources: 220"].waitForExistence(timeout: 2))
 
         XCTAssert(app.buttons["Select Mock Patient"].waitForExistence(timeout: 2))
         app.buttons["Select Mock Patient"].tap()
@@ -53,12 +55,13 @@ final class SpeziFHIRTests: XCTestCase {
         XCTAssert(app.staticTexts["Allergy Intolerances: 0"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Conditions: 37"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Diagnostics: 113"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Documents: 86"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Encounters: 86"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Immunizations: 11"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Medications: 55"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Observations: 169"].waitForExistence(timeout: 2))
         XCTAssert(app.staticTexts["Procedures: 225"].waitForExistence(timeout: 2))
-        XCTAssert(app.staticTexts["Other Resources: 322"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Other Resources: 236"].waitForExistence(timeout: 2))
     }
 
     func testAddingAndRemovingResources() throws {
@@ -94,24 +97,24 @@ final class SpeziFHIRTests: XCTestCase {
 
         app.navigationBars["Select Mock Patient"].buttons["Dismiss"].tap()
 
-        XCTAssert(app.staticTexts["Other Resources: 302"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Other Resources: 220"].waitForExistence(timeout: 2))
 
         // Add resource to mock patient
         XCTAssert(app.buttons["Add FHIR Resource"].waitForExistence(timeout: 2))
         app.buttons["Add FHIR Resource"].tap()
 
-        XCTAssert(app.staticTexts["Other Resources: 303"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Other Resources: 221"].waitForExistence(timeout: 2))
 
         // Remove resource from mock patient
         XCTAssert(app.buttons["Remove FHIR Resource"].waitForExistence(timeout: 2))
         app.buttons["Remove FHIR Resource"].tap()
 
-        XCTAssert(app.staticTexts["Other Resources: 302"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Other Resources: 220"].waitForExistence(timeout: 2))
 
         // Try removing a second time
         XCTAssert(app.buttons["Remove FHIR Resource"].waitForExistence(timeout: 2))
         app.buttons["Remove FHIR Resource"].tap()
 
-        XCTAssert(app.staticTexts["Other Resources: 302"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Other Resources: 220"].waitForExistence(timeout: 2))
     }
 }

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -553,8 +553,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziHealthKit.git";
 			requirement = {
-				branch = clinical;
-				kind = branch;
+				kind = upToNextMinorVersion;
+				minimumVersion = 0.6.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -16,6 +16,9 @@
 		2FBD9AFB2B01E4A800237A04 /* SpeziFHIRHealthKit in Frameworks */ = {isa = PBXBuildFile; productRef = 2FBD9AFA2B01E4A800237A04 /* SpeziFHIRHealthKit */; };
 		2FD021DD299E0F2900E5B91B /* TestAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FD021DC299E0F2900E5B91B /* TestAppDelegate.swift */; };
 		2FF6813F2A849F77002897C6 /* SpeziFHIR in Frameworks */ = {isa = PBXBuildFile; productRef = 2FF6813E2A849F77002897C6 /* SpeziFHIR */; };
+		65A9650B2D7CF01200F42471 /* TestingStandard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A9650A2D7CF01200F42471 /* TestingStandard.swift */; };
+		65A965112D7CF87500F42471 /* SpeziViews in Frameworks */ = {isa = PBXBuildFile; productRef = 65A965102D7CF87500F42471 /* SpeziViews */; };
+		65A965142D7CF89400F42471 /* SpeziHealthKit in Frameworks */ = {isa = PBXBuildFile; productRef = 65A965132D7CF89400F42471 /* SpeziHealthKit */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -39,6 +42,8 @@
 		2FA7382B290ADFAA007ACEB9 /* TestApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestApp.swift; sourceTree = "<group>"; };
 		2FC42FD7290ADD5E00B08F18 /* SpeziFHIR */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = SpeziFHIR; path = ../..; sourceTree = "<group>"; };
 		2FD021DC299E0F2900E5B91B /* TestAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestAppDelegate.swift; sourceTree = "<group>"; };
+		65A9650A2D7CF01200F42471 /* TestingStandard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestingStandard.swift; sourceTree = "<group>"; };
+		65A965152D7CF94700F42471 /* TestApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TestApp.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -49,6 +54,8 @@
 				2FBD9AFB2B01E4A800237A04 /* SpeziFHIRHealthKit in Frameworks */,
 				2FF6813F2A849F77002897C6 /* SpeziFHIR in Frameworks */,
 				2FBD9AF92B01E4A000237A04 /* SpeziFHIRMockPatients in Frameworks */,
+				65A965112D7CF87500F42471 /* SpeziViews in Frameworks */,
+				65A965142D7CF89400F42471 /* SpeziHealthKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -86,8 +93,10 @@
 		2F6D139428F5F384007C25D6 /* TestApp */ = {
 			isa = PBXGroup;
 			children = (
+				65A965152D7CF94700F42471 /* TestApp.entitlements */,
 				2FA7382B290ADFAA007ACEB9 /* TestApp.swift */,
 				2FD021DC299E0F2900E5B91B /* TestAppDelegate.swift */,
+				65A9650A2D7CF01200F42471 /* TestingStandard.swift */,
 				2F34D14D2B0CF1F1009300C1 /* ContentView.swift */,
 				2F34D1512B0CF59A009300C1 /* MockPatientSelection.swift */,
 				2F6D139928F5F386007C25D6 /* Assets.xcassets */,
@@ -131,6 +140,8 @@
 				2FF6813E2A849F77002897C6 /* SpeziFHIR */,
 				2FBD9AF82B01E4A000237A04 /* SpeziFHIRMockPatients */,
 				2FBD9AFA2B01E4A800237A04 /* SpeziFHIRHealthKit */,
+				65A965102D7CF87500F42471 /* SpeziViews */,
+				65A965132D7CF89400F42471 /* SpeziHealthKit */,
 			);
 			productName = Example;
 			productReference = 2F6D139228F5F384007C25D6 /* TestApp.app */;
@@ -185,6 +196,8 @@
 			);
 			mainGroup = 2F6D138928F5F384007C25D6;
 			packageReferences = (
+				65A9650F2D7CF87500F42471 /* XCRemoteSwiftPackageReference "SpeziViews" */,
+				65A965122D7CF89400F42471 /* XCRemoteSwiftPackageReference "SpeziHealthKit" */,
 			);
 			productRefGroup = 2F6D139328F5F384007C25D6 /* Products */;
 			projectDirPath = "";
@@ -242,6 +255,7 @@
 			files = (
 				2FA7382C290ADFAA007ACEB9 /* TestApp.swift in Sources */,
 				2FD021DD299E0F2900E5B91B /* TestAppDelegate.swift in Sources */,
+				65A9650B2D7CF01200F42471 /* TestingStandard.swift in Sources */,
 				2F34D1522B0CF59A009300C1 /* MockPatientSelection.swift in Sources */,
 				2F34D14E2B0CF1F1009300C1 /* ContentView.swift in Sources */,
 			);
@@ -389,13 +403,16 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = TestApp/TestApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "";
 				DEVELOPMENT_TEAM = 637867499T;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHealthClinicalHealthRecordsShareUsageDescription = "The Test App uses the health data to test the Spezi FHIR Package.";
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "The TestApp accesses your HealthKit data to run the tests.";
+				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "The Test App uses the health data to test the Spezi FHIR Package.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
@@ -422,13 +439,16 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = TestApp/TestApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "";
 				DEVELOPMENT_TEAM = 637867499T;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHealthClinicalHealthRecordsShareUsageDescription = "The Test App uses the health data to test the Spezi FHIR Package.";
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "The TestApp accesses your HealthKit data to run the tests.";
+				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "The Test App uses the health data to test the Spezi FHIR Package.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
@@ -520,6 +540,25 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		65A9650F2D7CF87500F42471 /* XCRemoteSwiftPackageReference "SpeziViews" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/StanfordSpezi/SpeziViews.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.9.1;
+			};
+		};
+		65A965122D7CF89400F42471 /* XCRemoteSwiftPackageReference "SpeziHealthKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/StanfordSpezi/SpeziHealthKit.git";
+			requirement = {
+				branch = clinical;
+				kind = branch;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		2FBD9AF82B01E4A000237A04 /* SpeziFHIRMockPatients */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -532,6 +571,16 @@
 		2FF6813E2A849F77002897C6 /* SpeziFHIR */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = SpeziFHIR;
+		};
+		65A965102D7CF87500F42471 /* SpeziViews */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 65A9650F2D7CF87500F42471 /* XCRemoteSwiftPackageReference "SpeziViews" */;
+			productName = SpeziViews;
+		};
+		65A965132D7CF89400F42471 /* SpeziHealthKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 65A965122D7CF89400F42471 /* XCRemoteSwiftPackageReference "SpeziHealthKit" */;
+			productName = SpeziHealthKit;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Tests/UITests/UITests.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Tests/UITests/UITests.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "932bcfc7d6fd1f33a8e5a8e6bc121d237315d806519bc31b8dec8f8a2abee3e1",
+  "originHash" : "4d13986aaafff4daffb297fc4d39f73a354b736afcb33615f772d0166f6f230f",
   "pins" : [
     {
       "identity" : "fhirmodels",
@@ -42,17 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziHealthKit",
       "state" : {
-        "branch" : "clinical",
-        "revision" : "4dc86ef4f7060edf57b20831bbc421517d73576b"
-      }
-    },
-    {
-      "identity" : "spezistorage",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/StanfordSpezi/SpeziStorage.git",
-      "state" : {
-        "revision" : "b5dfb4a551d3f4243e2798133d6da2414a70e274",
-        "version" : "2.1.0"
+        "revision" : "fbdec78fcb2f90d6338f1968e21dd11fbee65070",
+        "version" : "0.6.0"
       }
     },
     {

--- a/Tests/UITests/UITests.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Tests/UITests/UITests.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9b34b6536014597deb1ec711cbd71207d38c977060bbd264fb4930995e63e38e",
+  "originHash" : "932bcfc7d6fd1f33a8e5a8e6bc121d237315d806519bc31b8dec8f8a2abee3e1",
   "pins" : [
     {
       "identity" : "fhirmodels",
@@ -33,17 +33,44 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziFoundation",
       "state" : {
-        "revision" : "5b4ad1b343154b52a68c33a6bfe02d9cb07cb9dc",
-        "version" : "2.0.0"
+        "revision" : "78f3d912a82f951564d7e133867cf01351f53062",
+        "version" : "2.1.1"
       }
     },
     {
       "identity" : "spezihealthkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/StanfordSpezi/SpeziHealthKit.git",
+      "location" : "https://github.com/StanfordSpezi/SpeziHealthKit",
       "state" : {
-        "revision" : "fbdec78fcb2f90d6338f1968e21dd11fbee65070",
-        "version" : "0.6.0"
+        "branch" : "clinical",
+        "revision" : "4dc86ef4f7060edf57b20831bbc421517d73576b"
+      }
+    },
+    {
+      "identity" : "spezistorage",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/StanfordSpezi/SpeziStorage.git",
+      "state" : {
+        "revision" : "b5dfb4a551d3f4243e2798133d6da2414a70e274",
+        "version" : "2.1.0"
+      }
+    },
+    {
+      "identity" : "speziviews",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/StanfordSpezi/SpeziViews.git",
+      "state" : {
+        "revision" : "76be1e28a88c9a102524aded45f6c76850266110",
+        "version" : "1.9.1"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
       }
     },
     {
@@ -62,6 +89,15 @@
       "state" : {
         "revision" : "ee97538f5b81ae89698fd95938896dec5217b148",
         "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "e0ec0f5f3af6f3e4d5e7a19d2af26b481acb6ba8",
+        "version" : "1.0.3"
       }
     },
     {


### PR DESCRIPTION
# Support the Parsing and Extraction of Clinical Notes

## :recycle: Current situation & Problem
- SpeziFHIR currently doesn't currently explicit support documents as a dedicated resource type + as way to parse the information when extracting them from HealthKit.

## :gear: Release Notes
- Adds explicit document handling
- Improves FHIR parsing form HealthKit records 

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
