### PR TITLE
Improve Clinical Notes Extraction and Parsing Architecture

### DIFF
--- a/Sources/SpeziFHIR/FHIRAttachment/Base64Decoding.swift
+++ b/Sources/SpeziFHIR/FHIRAttachment/Base64Decoding.swift
@@ -1,0 +1,28 @@
+//
+// This source file is part of the Stanford Spezi open source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+
+/// Protocol for base64 decoding - makes testing possible.
+public protocol Base64Decoding {
+    /// Decodes a base64 string to Data.
+    /// - Parameter string: The base64 encoded string to decode.
+    /// - Returns: Decoded data or nil if invalid.
+    func decode(string: String) -> Data?
+}
+
+/// Default implementation using standard Data initializer.
+public struct DefaultBase64Decoder: Base64Decoding {
+    public init() {}
+
+
+    public func decode(string: String) -> Data? {
+        Data(base64Encoded: string)
+    }
+}

--- a/Sources/SpeziFHIR/FHIRAttachment/Base64Decoding.swift
+++ b/Sources/SpeziFHIR/FHIRAttachment/Base64Decoding.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 
+// swiftlint:disable file_types_order
 /// Protocol for base64 decoding - makes testing possible.
 protocol Base64Decoding {
     /// Decodes a base64 string to Data.

--- a/Sources/SpeziFHIR/FHIRAttachment/Base64Decoding.swift
+++ b/Sources/SpeziFHIR/FHIRAttachment/Base64Decoding.swift
@@ -10,7 +10,7 @@ import Foundation
 
 
 /// Protocol for base64 decoding - makes testing possible.
-public protocol Base64Decoding {
+protocol Base64Decoding {
     /// Decodes a base64 string to Data.
     /// - Parameter string: The base64 encoded string to decode.
     /// - Returns: Decoded data or nil if invalid.
@@ -18,11 +18,8 @@ public protocol Base64Decoding {
 }
 
 /// Default implementation using standard Data initializer.
-public struct DefaultBase64Decoder: Base64Decoding {
-    public init() {}
-
-
-    public func decode(string: String) -> Data? {
+struct DefaultBase64Decoder: Base64Decoding {
+    func decode(string: String) -> Data? {
         Data(base64Encoded: string)
     }
 }

--- a/Sources/SpeziFHIR/FHIRAttachment/ContentExtractor.swift
+++ b/Sources/SpeziFHIR/FHIRAttachment/ContentExtractor.swift
@@ -1,0 +1,79 @@
+//
+// This source file is part of the Stanford Spezi open source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import PDFKit
+import UniformTypeIdentifiers
+
+
+/// Protocol for content extraction strategies.
+public protocol ContentExtractor {
+    /// Determines if this extractor is compatible with the given content type.
+    /// - Parameter contentType: The content type to check.
+    /// - Returns: True if this extractor can handle the content type.
+    func isCompatible(with contentType: UTType) -> Bool
+
+    /// Extract readable content from data.
+    /// - Parameter data: Binary data to extract content from.
+    /// - Returns: Extracted text content.
+    /// - Throws: Error if extraction fails.
+    func extractContent(from data: Data) throws -> String
+}
+
+/// Extractor for plain text content types.
+public struct TextContentExtractor: ContentExtractor {
+    public init() {}
+
+
+    public func isCompatible(with contentType: UTType) -> Bool {
+        contentType.conforms(to: .text)
+    }
+
+    public func extractContent(from data: Data) throws -> String {
+        guard let string = String(data: data, encoding: .utf8) else {
+            throw FHIRAttachmentError.textDecodingFailed
+        }
+        return string
+    }
+}
+
+/// Extractor for PDF document content types.
+public struct PDFContentExtractor: ContentExtractor {
+    private let pdfDocumentProvider: PDFDocumentProviding
+
+
+    /// Creates a new instance of the PDF content extractor.
+    /// - Parameter pdfDocumentProvider: The provider used to create PDFDocument instances.
+    public init(pdfDocumentProvider: PDFDocumentProviding = DefaultPDFDocumentProvider()) {
+        self.pdfDocumentProvider = pdfDocumentProvider
+    }
+
+
+    public func isCompatible(with contentType: UTType) -> Bool {
+        contentType.conforms(to: .pdf)
+    }
+
+    public func extractContent(from data: Data) throws -> String {
+        guard let pdf = pdfDocumentProvider.createPDFDocument(from: data) else {
+            throw FHIRAttachmentError.pdfParsingFailed
+        }
+
+        let documentContent = NSMutableAttributedString()
+
+        for pageNumber in 0 ..< pdf.pageCount {
+            guard let page = pdf.page(at: pageNumber) else {
+                continue
+            }
+            guard let pageContent = page.attributedString else {
+                continue
+            }
+            documentContent.append(pageContent)
+        }
+
+        return documentContent.string
+    }
+}

--- a/Sources/SpeziFHIR/FHIRAttachment/ContentExtractor.swift
+++ b/Sources/SpeziFHIR/FHIRAttachment/ContentExtractor.swift
@@ -11,7 +11,7 @@ import UniformTypeIdentifiers
 
 
 /// Protocol for content extraction strategies.
-public protocol ContentExtractor {
+protocol ContentExtractor {
     /// Determines if this extractor is compatible with the given content type.
     /// - Parameter contentType: The content type to check.
     /// - Returns: True if this extractor can handle the content type.
@@ -25,15 +25,12 @@ public protocol ContentExtractor {
 }
 
 /// Extractor for plain text content types.
-public struct TextContentExtractor: ContentExtractor {
-    public init() {}
-
-
-    public func isCompatible(with contentType: UTType) -> Bool {
+struct TextContentExtractor: ContentExtractor {
+    func isCompatible(with contentType: UTType) -> Bool {
         contentType.conforms(to: .text)
     }
 
-    public func extractContent(from data: Data) throws -> String {
+    func extractContent(from data: Data) throws -> String {
         guard let string = String(data: data, encoding: .utf8) else {
             throw FHIRAttachmentError.textDecodingFailed
         }
@@ -42,22 +39,22 @@ public struct TextContentExtractor: ContentExtractor {
 }
 
 /// Extractor for PDF document content types.
-public struct PDFContentExtractor: ContentExtractor {
+struct PDFContentExtractor: ContentExtractor {
     private let pdfDocumentProvider: PDFDocumentProviding
 
 
     /// Creates a new instance of the PDF content extractor.
     /// - Parameter pdfDocumentProvider: The provider used to create PDFDocument instances.
-    public init(pdfDocumentProvider: PDFDocumentProviding = DefaultPDFDocumentProvider()) {
+    init(pdfDocumentProvider: PDFDocumentProviding = DefaultPDFDocumentProvider()) {
         self.pdfDocumentProvider = pdfDocumentProvider
     }
 
 
-    public func isCompatible(with contentType: UTType) -> Bool {
+    func isCompatible(with contentType: UTType) -> Bool {
         contentType.conforms(to: .pdf)
     }
 
-    public func extractContent(from data: Data) throws -> String {
+    func extractContent(from data: Data) throws -> String {
         guard let pdf = pdfDocumentProvider.createPDFDocument(from: data) else {
             throw FHIRAttachmentError.pdfParsingFailed
         }

--- a/Sources/SpeziFHIR/FHIRAttachment/ContentExtractor.swift
+++ b/Sources/SpeziFHIR/FHIRAttachment/ContentExtractor.swift
@@ -10,6 +10,7 @@ import PDFKit
 import UniformTypeIdentifiers
 
 
+// swiftlint:disable file_types_order
 /// Protocol for content extraction strategies.
 protocol ContentExtractor {
     /// Determines if this extractor is compatible with the given content type.

--- a/Sources/SpeziFHIR/FHIRAttachment/FHIRAttachment+DSTU2.swift
+++ b/Sources/SpeziFHIR/FHIRAttachment/FHIRAttachment+DSTU2.swift
@@ -11,7 +11,7 @@ import UniformTypeIdentifiers
 
 
 extension ModelsDSTU2.Attachment: FHIRAttachment {
-    public var debugDescription: String {
+    var debugDescription: String {
         """
         Could not transform attachement type: \(title?.primitiveDescription ?? "No title") to a string representation.
         
@@ -21,7 +21,7 @@ extension ModelsDSTU2.Attachment: FHIRAttachment {
         """
     }
     
-    public var mimeType: UTType? {
+    var mimeType: UTType? {
         guard let mimeTypeString = contentType?.value?.string,
               !mimeTypeString.isEmpty else {
             return nil
@@ -29,11 +29,11 @@ extension ModelsDSTU2.Attachment: FHIRAttachment {
         return UTType(mimeType: mimeTypeString)
     }
     
-    public var base64String: String? {
+    var base64String: String? {
         data?.value?.dataString
     }
 
-    public func encode(content: String) {
+    func encode(content: String) {
         data = FHIRPrimitive(ModelsDSTU2.Base64Binary(content))
     }
 }

--- a/Sources/SpeziFHIR/FHIRAttachment/FHIRAttachment+DSTU2.swift
+++ b/Sources/SpeziFHIR/FHIRAttachment/FHIRAttachment+DSTU2.swift
@@ -10,7 +10,7 @@ import ModelsDSTU2
 import UniformTypeIdentifiers
 
 
-extension ModelsDSTU2.Attachment: FHIRAttachement {
+extension ModelsDSTU2.Attachment: FHIRAttachment {
     public var debugDescription: String {
         """
         Could not transform attachement type: \(title?.primitiveDescription ?? "No title") to a string representation.
@@ -29,16 +29,11 @@ extension ModelsDSTU2.Attachment: FHIRAttachement {
         return UTType(mimeType: mimeTypeString)
     }
     
-    public var base64Data: String? {
-        get {
-            data?.value?.dataString
-        }
-        set {
-            guard let newValue else {
-                data = nil
-                return
-            }
-            data = FHIRPrimitive(ModelsDSTU2.Base64Binary(newValue))
-        }
+    public var base64String: String? {
+        data?.value?.dataString
+    }
+
+    public func encode(content: String) {
+        data = FHIRPrimitive(ModelsDSTU2.Base64Binary(content))
     }
 }

--- a/Sources/SpeziFHIR/FHIRAttachment/FHIRAttachment+R4.swift
+++ b/Sources/SpeziFHIR/FHIRAttachment/FHIRAttachment+R4.swift
@@ -10,7 +10,7 @@ import ModelsR4
 import UniformTypeIdentifiers
 
 
-extension ModelsR4.Attachment: FHIRAttachement {
+extension ModelsR4.Attachment: FHIRAttachment {
     public var debugDescription: String {
         """
         Could not transform attachement type: \(title?.primitiveDescription ?? "No title") to a string representation.
@@ -29,16 +29,11 @@ extension ModelsR4.Attachment: FHIRAttachement {
         return UTType(mimeType: mimeTypeString)
     }
     
-    public var base64Data: String? {
-        get {
-            data?.value?.dataString
-        }
-        set {
-            guard let newValue else {
-                data = nil
-                return
-            }
-            data = FHIRPrimitive(ModelsR4.Base64Binary(newValue))
-        }
+    public var base64String: String? {
+        data?.value?.dataString
+    }
+
+    public func encode(content: String) {
+        data = FHIRPrimitive(ModelsR4.Base64Binary(content))
     }
 }

--- a/Sources/SpeziFHIR/FHIRAttachment/FHIRAttachment+R4.swift
+++ b/Sources/SpeziFHIR/FHIRAttachment/FHIRAttachment+R4.swift
@@ -11,7 +11,7 @@ import UniformTypeIdentifiers
 
 
 extension ModelsR4.Attachment: FHIRAttachment {
-    public var debugDescription: String {
+    var debugDescription: String {
         """
         Could not transform attachement type: \(title?.primitiveDescription ?? "No title") to a string representation.
         
@@ -21,7 +21,7 @@ extension ModelsR4.Attachment: FHIRAttachment {
         """
     }
 
-    public var mimeType: UTType? {
+    var mimeType: UTType? {
         guard let mimeTypeString = contentType?.value?.string,
               !mimeTypeString.isEmpty else {
             return nil
@@ -29,11 +29,11 @@ extension ModelsR4.Attachment: FHIRAttachment {
         return UTType(mimeType: mimeTypeString)
     }
     
-    public var base64String: String? {
+    var base64String: String? {
         data?.value?.dataString
     }
 
-    public func encode(content: String) {
+    func encode(content: String) {
         data = FHIRPrimitive(ModelsR4.Base64Binary(content))
     }
 }

--- a/Sources/SpeziFHIR/FHIRAttachment/FHIRAttachment.swift
+++ b/Sources/SpeziFHIR/FHIRAttachment/FHIRAttachment.swift
@@ -19,7 +19,7 @@ protocol FHIRAttachment: AnyObject {
     /// Represents the content type of the attachment data (e.g., text/plain, application/pdf).
     var mimeType: UTType? { get }
 
-    /// Convenience property to get and set the Base64 string representation of the attachment data.
+    /// Convenience property to get the Base64 string representation of the attachment data.
     var base64String: String? { get }
 
     /// Encodes the provided string content into the FHIR attachment.

--- a/Sources/SpeziFHIR/FHIRAttachment/FHIRAttachment.swift
+++ b/Sources/SpeziFHIR/FHIRAttachment/FHIRAttachment.swift
@@ -10,23 +10,6 @@ import PDFKit
 import UniformTypeIdentifiers
 
 
-/// Uniform interface for FHIR attachment types.
-protocol FHIRAttachment: AnyObject {
-    /// Debug description of the attachment.
-    var debugDescription: String { get }
-
-    /// Best effort parsing of the MIME type of the attachment.
-    /// Represents the content type of the attachment data (e.g., text/plain, application/pdf).
-    var mimeType: UTType? { get }
-
-    /// Convenience property to get the Base64 string representation of the attachment data.
-    var base64String: String? { get }
-
-    /// Encodes the provided string content into the FHIR attachment.
-    /// - Parameter content: The string content to encode into the FHIR  attachment.
-    func encode(content: String)
-}
-
 /// Errors thrown while interacting with FHIR attachment types.
 enum FHIRAttachmentError: Error, Equatable {
     /// The attachment does not have a valid MIME type.
@@ -46,4 +29,21 @@ enum FHIRAttachmentError: Error, Equatable {
 
     /// The content type is not supported by any available extractor.
     case unsupportedContentType(UTType)
+}
+
+/// Uniform interface for FHIR attachment types.
+protocol FHIRAttachment: AnyObject {
+    /// Debug description of the attachment.
+    var debugDescription: String { get }
+
+    /// Best effort parsing of the MIME type of the attachment.
+    /// Represents the content type of the attachment data (e.g., text/plain, application/pdf).
+    var mimeType: UTType? { get }
+
+    /// Convenience property to get the Base64 string representation of the attachment data.
+    var base64String: String? { get }
+
+    /// Encodes the provided string content into the FHIR attachment.
+    /// - Parameter content: The string content to encode into the FHIR  attachment.
+    func encode(content: String)
 }

--- a/Sources/SpeziFHIR/FHIRAttachment/FHIRAttachment.swift
+++ b/Sources/SpeziFHIR/FHIRAttachment/FHIRAttachment.swift
@@ -11,7 +11,7 @@ import UniformTypeIdentifiers
 
 
 /// Uniform interface for FHIR attachment types.
-public protocol FHIRAttachment: AnyObject {
+protocol FHIRAttachment: AnyObject {
     /// Debug description of the attachment.
     var debugDescription: String { get }
 
@@ -27,20 +27,8 @@ public protocol FHIRAttachment: AnyObject {
     func encode(content: String)
 }
 
-extension FHIRAttachment {
-    /// Updates the attachment's base64String
-    ///
-    /// - Parameters:
-    ///   - service: Service to use for content extraction (injectable for testing).
-    /// - Throws: `FHIRAttachmentError` if transformation fails.
-    public func stringifyAttachment(using service: FHIRAttachmentService = FHIRAttachmentService()) throws {
-        let readableContent = try service.processAttachment(self)
-        encode(content: readableContent)
-    }
-}
-
 /// Errors thrown while interacting with FHIR attachment types.
-public enum FHIRAttachmentError: Error, Equatable {
+enum FHIRAttachmentError: Error, Equatable {
     /// The attachment does not have a valid MIME type.
     case missingMimeType
 

--- a/Sources/SpeziFHIR/FHIRAttachment/FHIRAttachment.swift
+++ b/Sources/SpeziFHIR/FHIRAttachment/FHIRAttachment.swift
@@ -11,64 +11,51 @@ import UniformTypeIdentifiers
 
 
 /// Uniform interface for FHIR attachment types.
-public protocol FHIRAttachement: AnyObject {
-    /// Debug description of the attachment
+public protocol FHIRAttachment: AnyObject {
+    /// Debug description of the attachment.
     var debugDescription: String { get }
+
     /// Best effort parsing of the MIME type of the attachment.
+    /// Represents the content type of the attachment data (e.g., text/plain, application/pdf).
     var mimeType: UTType? { get }
+
     /// Convenience property to get and set the Base64 string representation of the attachment data.
-    var base64Data: String? { get set }
+    var base64String: String? { get }
+
+    /// Encodes the provided string content into the FHIR attachment.
+    /// - Parameter content: The string content to encode into the FHIR  attachment.
+    func encode(content: String)
 }
 
+extension FHIRAttachment {
+    /// Updates the attachment's base64String
+    ///
+    /// - Parameters:
+    ///   - service: Service to use for content extraction (injectable for testing).
+    /// - Throws: `FHIRAttachmentError` if transformation fails.
+    public func stringifyAttachment(using service: FHIRAttachmentService = FHIRAttachmentService()) throws {
+        let readableContent = try service.processAttachment(self)
+        encode(content: readableContent)
+    }
+}
 
 /// Errors thrown while interacting with FHIR attachment types.
-public enum FHIRAttachmentError: Error {
-    /// Invalid base 64 data.
+public enum FHIRAttachmentError: Error, Equatable {
+    /// The attachment does not have a valid MIME type.
+    case missingMimeType
+
+    /// The attachment does not contain any base64-encoded string.
+    case missingBase64String
+
+    /// The base64 string couldn't be decoded into valid binary data.
     case invalidBase64Data
-    /// Error parsing the attached MIME type.
-    case cannotParseMIMEType(UTType)
-}
 
+    /// The text data couldn't be decoded using UTF-8 encoding.
+    case textDecodingFailed
 
-extension FHIRAttachement {
-    /// Best effort function to transform the base64 data representatino of an ``FHIRAttachement`` to a string-based respresentation of the data type.
-    ///
-    /// This funcationality is especially useful if the data content is inspected for debug purposes or passing it ot a LLM component.
-    public func stringifyAttachements() throws {
-        // We inject the data right in the resource if it has the same content type.
-        // There are a few shortcomings of this appraoch:
-        // 1. We assume that the content type is a MIME type, we would need to more checks around the content.format to be fully correct.
-        // 2. The data property expects a Base64 encoded String. This is according to the FHIR spec but we don't check this in detail here.
-        guard let contentType = mimeType,
-              let base64String = base64Data,
-              let data = Data(base64Encoded: base64String) else {
-            throw FHIRAttachmentError.invalidBase64Data
-        }
-        
-        if contentType.conforms(to: .text) {
-            base64Data = String(decoding: data, as: UTF8.self)
-        } else if contentType.conforms(to: .pdf) {
-            guard let pdf = PDFDocument(data: data) else {
-                throw FHIRAttachmentError.cannotParseMIMEType(contentType)
-            }
-            
-            let pageCount = pdf.pageCount
-            let documentContent = NSMutableAttributedString()
-            
-            for pageNumber in 0 ..< pageCount {
-                guard let page = pdf.page(at: pageNumber) else {
-                    continue
-                }
-                guard let pageContent = page.attributedString else {
-                    continue
-                }
-                documentContent.append(pageContent)
-            }
-            
-            base64Data = documentContent.string
-        } else {
-            print(debugDescription)
-            throw FHIRAttachmentError.cannotParseMIMEType(contentType)
-        }
-    }
+    /// The data couldn't be parsed as a valid PDF document.
+    case pdfParsingFailed
+
+    /// The content type is not supported by any available extractor.
+    case unsupportedContentType(UTType)
 }

--- a/Sources/SpeziFHIR/FHIRAttachment/FHIRAttachmentService.swift
+++ b/Sources/SpeziFHIR/FHIRAttachment/FHIRAttachmentService.swift
@@ -69,4 +69,3 @@ struct FHIRAttachmentService {
          }
     }
 }
-

--- a/Sources/SpeziFHIR/FHIRAttachment/FHIRAttachmentService.swift
+++ b/Sources/SpeziFHIR/FHIRAttachment/FHIRAttachmentService.swift
@@ -1,0 +1,62 @@
+//
+// This source file is part of the Stanford Spezi open source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import UniformTypeIdentifiers
+
+
+/// Service to handle FHIR attachment content extraction.
+public struct FHIRAttachmentService {
+    private let contentExtractors: [ContentExtractor]
+    private let base64Decoder: Base64Decoding
+
+
+    /// Creates a new attachment service instance.
+    /// - Parameters:
+    ///   - contentExtractors: Collection of content extractors to use (defaults to text and PDF).
+    ///   - base64Decoder: The base64 decoder to use.
+    public init(
+        contentExtractors: [ContentExtractor] = [TextContentExtractor(), PDFContentExtractor()],
+        base64Decoder: Base64Decoding = DefaultBase64Decoder()
+    ) {
+        self.contentExtractors = contentExtractors
+        self.base64Decoder = base64Decoder
+    }
+
+
+    /// Processes an attachment and converts its binary content to a readable string.
+    /// - Parameter attachment: The FHIR attachment to process.
+    /// - Returns: Extracted content as a string.
+    /// - Throws: FHIRAttachmentError if processing fails.
+    public func processAttachment(_ attachment: FHIRAttachment) throws -> String {
+        guard let contentType = attachment.mimeType else {
+            throw FHIRAttachmentError.missingMimeType
+        }
+
+        guard let encodedString = attachment.base64String else {
+            throw FHIRAttachmentError.missingBase64String
+        }
+
+        guard let data = base64Decoder.decode(string: encodedString) else {
+            throw FHIRAttachmentError.invalidBase64Data
+        }
+
+        guard let extractor = contentExtractor(for: contentType) else {
+            throw FHIRAttachmentError.unsupportedContentType(contentType)
+        }
+
+        let content = try extractor.extractContent(from: data)
+        return content
+    }
+
+    private func contentExtractor(for contentType: UTType) -> ContentExtractor? {
+         contentExtractors.first { extractor in
+             extractor.isCompatible(with: contentType)
+         }
+    }
+}
+

--- a/Sources/SpeziFHIR/FHIRAttachment/FHIRAttachmentService.swift
+++ b/Sources/SpeziFHIR/FHIRAttachment/FHIRAttachmentService.swift
@@ -10,7 +10,7 @@ import UniformTypeIdentifiers
 
 
 /// Service to handle FHIR attachment content extraction.
-public struct FHIRAttachmentService {
+struct FHIRAttachmentService {
     private let contentExtractors: [ContentExtractor]
     private let base64Decoder: Base64Decoding
 
@@ -19,7 +19,7 @@ public struct FHIRAttachmentService {
     /// - Parameters:
     ///   - contentExtractors: Collection of content extractors to use (defaults to text and PDF).
     ///   - base64Decoder: The base64 decoder to use.
-    public init(
+    init(
         contentExtractors: [ContentExtractor] = [TextContentExtractor(), PDFContentExtractor()],
         base64Decoder: Base64Decoding = DefaultBase64Decoder()
     ) {
@@ -28,11 +28,21 @@ public struct FHIRAttachmentService {
     }
 
 
-    /// Processes an attachment and converts its binary content to a readable string.
-    /// - Parameter attachment: The FHIR attachment to process.
-    /// - Returns: Extracted content as a string.
-    /// - Throws: FHIRAttachmentError if processing fails.
-    public func processAttachment(_ attachment: FHIRAttachment) throws -> String {
+    /// Transforms a FHIR attachment's base64-encoded data into human-readable text.
+    ///
+    /// This method extracts text content from various attachment formats (PDF, text files, etc.)
+    /// based on their MIME type and replaces the original binary content with the extracted text,
+    /// re-encoded as base64 to maintain FHIR data structure compatibility.
+    ///
+    /// - Parameter attachment: The FHIR attachment to transform.
+    /// - Throws: `FHIRAttachmentError` if the transformation fails for any reason,
+    ///           such as missing MIME type, invalid base64 data, or unsupported content type.
+    func stringify(attachment: FHIRAttachment) throws {
+        let content = try processAttachment(attachment)
+        attachment.encode(content: content)
+    }
+
+    private func processAttachment(_ attachment: FHIRAttachment) throws -> String {
         guard let contentType = attachment.mimeType else {
             throw FHIRAttachmentError.missingMimeType
         }

--- a/Sources/SpeziFHIR/FHIRAttachment/FHIRResource+StringifyAttachment.swift
+++ b/Sources/SpeziFHIR/FHIRAttachment/FHIRResource+StringifyAttachment.swift
@@ -14,7 +14,7 @@ extension FHIRResource {
     /// Best effort function to transform the base64 data representatino of any ``FHIRAttachement`` to a string-based respresentation of the data type.
     ///
     /// This funcationality is especially useful if the data content is inspected for debug purposes or passing it ot a LLM component.
-    public func stringifyAttachements() throws {
+    public func stringifyAttachements(using service: FHIRAttachmentService = FHIRAttachmentService()) throws {
         switch versionedResource {
         case let .r4(r4Resource):
             guard let documentReference = r4Resource as? ModelsR4.DocumentReference else {
@@ -22,7 +22,7 @@ extension FHIRResource {
             }
             
             for attachement in documentReference.content.compactMap(\.attachment) {
-                try attachement.stringifyAttachements()
+                try attachement.stringifyAttachment(using: service)
             }
         case let .dstu2(dstu2Resource):
             guard let documentReference = dstu2Resource as? ModelsDSTU2.DocumentReference else {
@@ -30,7 +30,7 @@ extension FHIRResource {
             }
             
             for attachement in documentReference.content.compactMap(\.attachment) {
-                try attachement.stringifyAttachements()
+                try attachement.stringifyAttachment(using: service)
             }
         }
     }

--- a/Sources/SpeziFHIR/FHIRAttachment/PDFDocumentProviding.swift
+++ b/Sources/SpeziFHIR/FHIRAttachment/PDFDocumentProviding.swift
@@ -9,6 +9,7 @@
 import PDFKit
 
 
+// swiftlint:disable file_types_order
 /// Protocol for creating PDFDocument objects - makes testing possible.
 protocol PDFDocumentProviding {
     /// Creates a PDF document from raw data.
@@ -23,4 +24,3 @@ struct DefaultPDFDocumentProvider: PDFDocumentProviding {
         PDFDocument(data: data)
     }
 }
-

--- a/Sources/SpeziFHIR/FHIRAttachment/PDFDocumentProviding.swift
+++ b/Sources/SpeziFHIR/FHIRAttachment/PDFDocumentProviding.swift
@@ -10,7 +10,7 @@ import PDFKit
 
 
 /// Protocol for creating PDFDocument objects - makes testing possible.
-public protocol PDFDocumentProviding {
+protocol PDFDocumentProviding {
     /// Creates a PDF document from raw data.
     /// - Parameter data: The PDF data to create a document from.
     /// - Returns: A PDFDocument if valid, nil otherwise.
@@ -18,11 +18,8 @@ public protocol PDFDocumentProviding {
 }
 
 /// Default implementation using the PDFDocument class from PDFKit.
-public struct DefaultPDFDocumentProvider: PDFDocumentProviding {
-    public init() {}
-
-
-    public func createPDFDocument(from data: Data) -> PDFDocument? {
+struct DefaultPDFDocumentProvider: PDFDocumentProviding {
+    func createPDFDocument(from data: Data) -> PDFDocument? {
         PDFDocument(data: data)
     }
 }

--- a/Sources/SpeziFHIR/FHIRAttachment/PDFDocumentProviding.swift
+++ b/Sources/SpeziFHIR/FHIRAttachment/PDFDocumentProviding.swift
@@ -1,0 +1,29 @@
+//
+// This source file is part of the Stanford Spezi open source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import PDFKit
+
+
+/// Protocol for creating PDFDocument objects - makes testing possible.
+public protocol PDFDocumentProviding {
+    /// Creates a PDF document from raw data.
+    /// - Parameter data: The PDF data to create a document from.
+    /// - Returns: A PDFDocument if valid, nil otherwise.
+    func createPDFDocument(from data: Data) -> PDFDocument?
+}
+
+/// Default implementation using the PDFDocument class from PDFKit.
+public struct DefaultPDFDocumentProvider: PDFDocumentProviding {
+    public init() {}
+
+
+    public func createPDFDocument(from data: Data) -> PDFDocument? {
+        PDFDocument(data: data)
+    }
+}
+

--- a/Sources/SpeziFHIR/FHIRResource/FHIRResource+StringifyAttachment.swift
+++ b/Sources/SpeziFHIR/FHIRResource/FHIRResource+StringifyAttachment.swift
@@ -14,7 +14,11 @@ extension FHIRResource {
     /// Best effort function to transform the base64 data representatino of any ``FHIRAttachement`` to a string-based respresentation of the data type.
     ///
     /// This funcationality is especially useful if the data content is inspected for debug purposes or passing it ot a LLM component.
-    public func stringifyAttachements(using service: FHIRAttachmentService = FHIRAttachmentService()) throws {
+    public func stringifyAttachements() throws {
+        try stringifyAttachements(using: FHIRAttachmentService())
+    }
+
+    func stringifyAttachements(using service: FHIRAttachmentService) throws {
         switch versionedResource {
         case let .r4(r4Resource):
             guard let documentReference = r4Resource as? ModelsR4.DocumentReference else {
@@ -22,7 +26,7 @@ extension FHIRResource {
             }
             
             for attachement in documentReference.content.compactMap(\.attachment) {
-                try attachement.stringifyAttachment(using: service)
+                try service.stringify(attachment: attachement)
             }
         case let .dstu2(dstu2Resource):
             guard let documentReference = dstu2Resource as? ModelsDSTU2.DocumentReference else {
@@ -30,7 +34,7 @@ extension FHIRResource {
             }
             
             for attachement in documentReference.content.compactMap(\.attachment) {
-                try attachement.stringifyAttachment(using: service)
+                try service.stringify(attachment: attachement)
             }
         }
     }

--- a/Tests/SpeziFHIRTests/FHIRAttachment/Base64DecoderTests.swift
+++ b/Tests/SpeziFHIRTests/FHIRAttachment/Base64DecoderTests.swift
@@ -6,13 +6,13 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Testing
+import ModelsR4
 @testable import SpeziFHIR
 import Testing
-import ModelsR4
 
 
-@Suite struct Base64DecoderTests {
+@Suite
+struct Base64DecoderTests {
     private let decoder = DefaultBase64Decoder()
 
     @Test("Successfully decodes valid base64 string")

--- a/Tests/SpeziFHIRTests/FHIRAttachment/Base64DecoderTests.swift
+++ b/Tests/SpeziFHIRTests/FHIRAttachment/Base64DecoderTests.swift
@@ -1,0 +1,37 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Testing
+@testable import SpeziFHIR
+import Testing
+import ModelsR4
+
+
+@Suite struct Base64DecoderTests {
+    private let decoder = DefaultBase64Decoder()
+
+    @Test("Successfully decodes valid base64 string")
+    func testValidBase64Decoding() {
+        let base64String = "V2VsY29tZSB0byBTcGV6aUZISVI="
+        let data = decoder.decode(string: base64String)
+
+        #expect(data != nil)
+        if let data = data {
+            let decodedString = String(data: data, encoding: .utf8)
+            #expect(decodedString == "Welcome to SpeziFHIR")
+        }
+    }
+
+    @Test("Returns nil for invalid base64 string")
+    func testInvalidBase64Decoding() {
+        let invalidBase64 = "This is not base64!"
+        let data = decoder.decode(string: invalidBase64)
+
+        #expect(data == nil)
+    }
+}

--- a/Tests/SpeziFHIRTests/FHIRAttachment/FHIRAttachmentServiceTests.swift
+++ b/Tests/SpeziFHIRTests/FHIRAttachment/FHIRAttachmentServiceTests.swift
@@ -1,0 +1,153 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Testing
+@testable import SpeziFHIR
+import PDFKit
+import UniformTypeIdentifiers
+
+
+@Suite struct FHIRAttachmentServiceTests {
+    @Test("Successfully stringifies text content")
+    func testStringifyTextContent() throws {
+        let base64Decoder = DefaultBase64Decoder()
+        let textType = UTType(mimeType: "text/plain")
+        let textContentExtractor = TextContentExtractor()
+
+        let service = FHIRAttachmentService(
+            contentExtractors: [textContentExtractor],
+            base64Decoder: base64Decoder
+        )
+
+        let attachment = MockFHIRAttachment()
+        attachment.mimeType = textType
+        attachment.base64String = "V2VsY29tZSB0byBTcGV6aUZISVI="
+
+        try service.stringify(attachment: attachment)
+
+        #expect(attachment.encodedContent == "Welcome to SpeziFHIR")
+    }
+
+    @Test("Successfully stringifies PDF content")
+   func testStringifyPDFContent() throws {
+       let base64Decoder = DefaultBase64Decoder()
+       let pdfType = UTType(mimeType: "application/pdf")!
+       let pdfContentExtractor = PDFContentExtractor(pdfDocumentProvider: DefaultPDFDocumentProvider())
+
+       let service = FHIRAttachmentService(
+           contentExtractors: [pdfContentExtractor],
+           base64Decoder: base64Decoder
+       )
+
+        let attachment = MockFHIRAttachment()
+        attachment.mimeType = pdfType
+        attachment.base64String = "JVBERi0xLjQKMSAwIG9iago8PCAvVHlwZSAvQ2F0YWxvZyAvUGFnZXMgMiAwIFIgPj4KZW5kb2JqCjIgMCBvYmoKPDwgL1R5cGUgL1BhZ2VzIC9LaWRzIFszIDAgUl0gL0NvdW50IDEgPj4KZW5kb2JqCjMgMCBvYmoKPDwgL1R5cGUgL1BhZ2UgL1BhcmVudCAyIDAgUiAvTWVkaWFCb3ggWzAgMCA2MTIgNzkyXSAvUmVzb3VyY2VzIDw8IC9Gb250IDw8IC9GMSA0IDAgUiA+PiA+PiAvQ29udGVudHMgNSAwIFIgPj4KZW5kb2JqCjQgMCBvYmoKPDwgL1R5cGUgL0ZvbnQgL1N1YnR5cGUgL1R5cGUxIC9CYXNlRm9udCAvSGVsdmV0aWNhID4+CmVuZG9iago1IDAgb2JqCjw8IC9MZW5ndGggNDQgPj4Kc3RyZWFtCkJUCi9GMSAxNiBUZgo1MCA3MDAgVGQKKFBERjogV2VsY29tZSB0byBTcGV6aUZISVIpIFRqCkVUCmVuZHN0cmVhbQplbmRvYmoKeHJlZgowIDYKMDAwMDAwMDAwMCA2NTUzNSBmCjAwMDAwMDAwMDkgMDAwMDAgbgowMDAwMDAwMDU4IDAwMDAwIG4KMDAwMDAwMDExNSAwMDAwMCBuCjAwMDAwMDAyMjkgMDAwMDAgbgowMDAwMDAwMjk1IDAwMDAwIG4KdHJhaWxlcgo8PCAvU2l6ZSA2IC9Sb290IDEgMCBSID4+CnN0YXJ0eHJlZgozOTEKJSVFT0Y="
+
+       try service.stringify(attachment: attachment)
+
+       #expect(attachment.encodedContent == "PDF: Welcome to SpeziFHIR")
+   }
+
+    @Test("Throws error when MIME type is missing")
+    func testMissingMimeType() throws {
+        let service = FHIRAttachmentService()
+
+        let attachment = MockFHIRAttachment()
+        attachment.mimeType = nil
+        attachment.base64String = "V2VsY29tZSB0byBTcGV6aUZISVI="
+
+        do {
+            try service.stringify(attachment: attachment)
+        } catch let error as FHIRAttachmentError {
+            #expect(error == .missingMimeType)
+        }
+    }
+
+    @Test("Throws error when base64 string is missing")
+    func testMissingBase64String() throws {
+        let service = FHIRAttachmentService()
+
+        let attachment = MockFHIRAttachment()
+        attachment.mimeType = UTType(mimeType: "text/plain")
+        attachment.base64String = nil
+
+        do {
+            try service.stringify(attachment: attachment)
+        } catch let error as FHIRAttachmentError {
+            #expect(error == .missingBase64String)
+        }
+    }
+
+    @Test("Throws error when base64 data is invalid")
+    func testInvalidBase64Data() throws {
+        let base64Decoder = DefaultBase64Decoder()
+        let service = FHIRAttachmentService(base64Decoder: base64Decoder)
+
+        let attachment = MockFHIRAttachment()
+        attachment.mimeType = UTType(mimeType: "text/plain")
+        attachment.base64String = "invalid-base64-string"
+
+        do {
+            try service.stringify(attachment: attachment)
+        } catch let error as FHIRAttachmentError {
+            #expect(error == .invalidBase64Data)
+        }
+    }
+
+    @Test("Throws error when content type is unsupported")
+    func testUnsupportedContentType() throws {
+        let base64Decoder = DefaultBase64Decoder()
+        let textContextExtractor = TextContentExtractor()
+        let service = FHIRAttachmentService(
+            contentExtractors: [textContextExtractor],
+            base64Decoder: base64Decoder
+        )
+
+        let customType = UTType(mimeType: "application/custom")
+        let attachment = MockFHIRAttachment()
+        attachment.mimeType = customType
+        attachment.base64String = "V2VsY29tZSB0byBTcGV6aUZISVI="
+
+        do {
+            try service.stringify(attachment: attachment)
+        } catch let error as FHIRAttachmentError {
+            #expect(error == .unsupportedContentType(customType!))
+        }
+    }
+
+    @Test("Throws error when no extractors are available")
+    func testServiceWithEmptyExtractors() throws {
+        let mockDecoder = DefaultBase64Decoder()
+        let service = FHIRAttachmentService(
+            contentExtractors: [],
+            base64Decoder: mockDecoder
+        )
+
+        let textPlainType = UTType(mimeType: "text/plain")
+        let attachment = MockFHIRAttachment()
+        attachment.mimeType = textPlainType
+        attachment.base64String = "SGVsbG8sIHdvcmxkIQ=="
+
+        do {
+            try service.stringify(attachment: attachment)
+        } catch let error as FHIRAttachmentError {
+            #expect(error == .unsupportedContentType(textPlainType!))
+        }
+    }
+}
+
+private final class MockFHIRAttachment: FHIRAttachment {
+    var debugDescription: String = "Mock FHIR Attachment"
+    var mimeType: UTType?
+    var base64String: String?
+    var encodedContent: String?
+
+    func encode(content: String) {
+        encodedContent = content
+    }
+}

--- a/Tests/SpeziFHIRTests/FHIRAttachment/FHIRAttachmentTests.swift
+++ b/Tests/SpeziFHIRTests/FHIRAttachment/FHIRAttachmentTests.swift
@@ -6,16 +6,16 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Testing
-@testable import SpeziFHIR
 import ModelsDSTU2
 import ModelsR4
+@testable import SpeziFHIR
+import Testing
 import UniformTypeIdentifiers
 
 
-enum FHIRVersion {
+enum FHIRModel {
     case dstu2
-    case r4
+    case r4  // swiftlint:disable:this identifier_name
 
     var description: String {
         switch self {
@@ -25,9 +25,9 @@ enum FHIRVersion {
     }
 }
 
-struct FHIRAttachmentTestHelper {
-    static func createAttachment(version: FHIRVersion) -> any FHIRAttachment {
-        switch version {
+enum FHIRAttachmentTestHelper {
+    static func createAttachment(model: FHIRModel) -> any FHIRAttachment {
+        switch model {
         case .dstu2:
             return ModelsDSTU2.Attachment()
         case .r4:
@@ -35,8 +35,8 @@ struct FHIRAttachmentTestHelper {
         }
     }
 
-    static func createAttachmentWithContentType(_ contentType: String, version: FHIRVersion) -> any FHIRAttachment {
-        switch version {
+    static func createAttachmentWithContentType(_ contentType: String, model: FHIRModel) -> any FHIRAttachment {
+        switch model {
         case .dstu2:
             let attachment = ModelsDSTU2.Attachment()
             attachment.contentType = FHIRPrimitive(stringLiteral: contentType)
@@ -48,8 +48,8 @@ struct FHIRAttachmentTestHelper {
         }
     }
 
-    static func createAttachmentWithData(_ data: String, version: FHIRVersion) -> any FHIRAttachment {
-        switch version {
+    static func createAttachmentWithData(_ data: String, model: FHIRModel) -> any FHIRAttachment {
+        switch model {
         case .dstu2:
             let attachment = ModelsDSTU2.Attachment()
             attachment.data = FHIRPrimitive(ModelsDSTU2.Base64Binary(data))
@@ -62,75 +62,75 @@ struct FHIRAttachmentTestHelper {
     }
 }
 
-@Suite struct FHIRAttachmentTests {
-
+@Suite
+struct FHIRAttachmentTests {
     @Test(
         "Attachment returns correct mime type",
-        arguments: [FHIRVersion.dstu2, FHIRVersion.r4]
+        arguments: [FHIRModel.dstu2, FHIRModel.r4]
     )
-    func testMimeType(_ version: FHIRVersion) {
-        let attachment = FHIRAttachmentTestHelper.createAttachmentWithContentType("text/plain", version: version)
+    func testMimeType(_ model: FHIRModel) {
+        let attachment = FHIRAttachmentTestHelper.createAttachmentWithContentType("text/plain", model: model)
         let mimeType = attachment.mimeType
 
-        #expect(mimeType != nil, "\(version.description) attachment should have non-nil MIME type")
-        #expect(mimeType?.preferredMIMEType == "text/plain", "\(version.description) attachment should have correct MIME type")
+        #expect(mimeType != nil, "\(model.description) attachment should have non-nil MIME type")
+        #expect(mimeType?.preferredMIMEType == "text/plain", "\(model.description) attachment should have correct MIME type")
     }
 
     @Test(
         "Attachment returns nil for empty mime type",
-        arguments: [FHIRVersion.dstu2, FHIRVersion.r4]
+        arguments: [FHIRModel.dstu2, FHIRModel.r4]
     )
-    func testEmptyMimeType(_ version: FHIRVersion) {
-        let attachment = FHIRAttachmentTestHelper.createAttachmentWithContentType("", version: version)
+    func testEmptyMimeType(_ model: FHIRModel) {
+        let attachment = FHIRAttachmentTestHelper.createAttachmentWithContentType("", model: model)
         let mimeType = attachment.mimeType
 
-        #expect(mimeType == nil, "\(version.description) attachment should return nil for empty MIME type")
+        #expect(mimeType == nil, "\(model.description) attachment should return nil for empty MIME type")
     }
 
     @Test(
         "Attachment returns nil for missing mime type",
-        arguments: [FHIRVersion.dstu2, FHIRVersion.r4]
+        arguments: [FHIRModel.dstu2, FHIRModel.r4]
     )
-    func testMissingMimeType(_ version: FHIRVersion) {
-        let attachment = FHIRAttachmentTestHelper.createAttachment(version: version)
+    func testMissingMimeType(_ model: FHIRModel) {
+        let attachment = FHIRAttachmentTestHelper.createAttachment(model: model)
         let mimeType = attachment.mimeType
 
-        #expect(mimeType == nil, "\(version.description) attachment should return nil for missing MIME type")
+        #expect(mimeType == nil, "\(model.description) attachment should return nil for missing MIME type")
     }
 
     @Test(
         "Attachment returns base64 string",
-        arguments: [FHIRVersion.dstu2, FHIRVersion.r4]
+        arguments: [FHIRModel.dstu2, FHIRModel.r4]
     )
-    func testBase64String(_ version: FHIRVersion) {
+    func testBase64String(_ model: FHIRModel) {
         let testString = "Test content"
-        let attachment = FHIRAttachmentTestHelper.createAttachmentWithData(testString, version: version)
+        let attachment = FHIRAttachmentTestHelper.createAttachmentWithData(testString, model: model)
         let base64String = attachment.base64String
 
-        #expect(base64String == testString, "\(version.description) attachment should return correct base64 string")
+        #expect(base64String == testString, "\(model.description) attachment should return correct base64 string")
     }
 
     @Test(
         "Attachment returns nil for missing base64 string",
-        arguments: [FHIRVersion.dstu2, FHIRVersion.r4]
+        arguments: [FHIRModel.dstu2, FHIRModel.r4]
     )
-    func testMissingBase64String(_ version: FHIRVersion) {
-        let attachment = FHIRAttachmentTestHelper.createAttachment(version: version)
+    func testMissingBase64String(_ model: FHIRModel) {
+        let attachment = FHIRAttachmentTestHelper.createAttachment(model: model)
         let base64String = attachment.base64String
 
-        #expect(base64String == nil, "\(version.description) attachment should return nil for missing base64 string")
+        #expect(base64String == nil, "\(model.description) attachment should return nil for missing base64 string")
     }
 
     @Test(
         "Attachment encodes content correctly",
-        arguments: [FHIRVersion.dstu2, FHIRVersion.r4]
+        arguments: [FHIRModel.dstu2, FHIRModel.r4]
     )
-    func testEncodeContent(_ version: FHIRVersion) {
-        let attachment = FHIRAttachmentTestHelper.createAttachment(version: version)
+    func testEncodeContent(_ model: FHIRModel) {
+        let attachment = FHIRAttachmentTestHelper.createAttachment(model: model)
         let testContent = "This is test content"
 
         attachment.encode(content: testContent)
 
-        #expect(attachment.base64String == testContent, "\(version.description) attachment should encode content correctly")
+        #expect(attachment.base64String == testContent, "\(model.description) attachment should encode content correctly")
     }
 }

--- a/Tests/SpeziFHIRTests/FHIRAttachment/FHIRAttachmentTests.swift
+++ b/Tests/SpeziFHIRTests/FHIRAttachment/FHIRAttachmentTests.swift
@@ -1,0 +1,136 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Testing
+@testable import SpeziFHIR
+import ModelsDSTU2
+import ModelsR4
+import UniformTypeIdentifiers
+
+
+enum FHIRVersion {
+    case dstu2
+    case r4
+
+    var description: String {
+        switch self {
+        case .dstu2: return "DSTU2"
+        case .r4: return "R4"
+        }
+    }
+}
+
+struct FHIRAttachmentTestHelper {
+    static func createAttachment(version: FHIRVersion) -> any FHIRAttachment {
+        switch version {
+        case .dstu2:
+            return ModelsDSTU2.Attachment()
+        case .r4:
+            return ModelsR4.Attachment()
+        }
+    }
+
+    static func createAttachmentWithContentType(_ contentType: String, version: FHIRVersion) -> any FHIRAttachment {
+        switch version {
+        case .dstu2:
+            let attachment = ModelsDSTU2.Attachment()
+            attachment.contentType = FHIRPrimitive(stringLiteral: contentType)
+            return attachment
+        case .r4:
+            let attachment = ModelsR4.Attachment()
+            attachment.contentType = FHIRPrimitive(stringLiteral: contentType)
+            return attachment
+        }
+    }
+
+    static func createAttachmentWithData(_ data: String, version: FHIRVersion) -> any FHIRAttachment {
+        switch version {
+        case .dstu2:
+            let attachment = ModelsDSTU2.Attachment()
+            attachment.data = FHIRPrimitive(ModelsDSTU2.Base64Binary(data))
+            return attachment
+        case .r4:
+            let attachment = ModelsR4.Attachment()
+            attachment.data = FHIRPrimitive(ModelsR4.Base64Binary(data))
+            return attachment
+        }
+    }
+}
+
+@Suite struct FHIRAttachmentTests {
+
+    @Test(
+        "Attachment returns correct mime type",
+        arguments: [FHIRVersion.dstu2, FHIRVersion.r4]
+    )
+    func testMimeType(_ version: FHIRVersion) {
+        let attachment = FHIRAttachmentTestHelper.createAttachmentWithContentType("text/plain", version: version)
+        let mimeType = attachment.mimeType
+
+        #expect(mimeType != nil, "\(version.description) attachment should have non-nil MIME type")
+        #expect(mimeType?.preferredMIMEType == "text/plain", "\(version.description) attachment should have correct MIME type")
+    }
+
+    @Test(
+        "Attachment returns nil for empty mime type",
+        arguments: [FHIRVersion.dstu2, FHIRVersion.r4]
+    )
+    func testEmptyMimeType(_ version: FHIRVersion) {
+        let attachment = FHIRAttachmentTestHelper.createAttachmentWithContentType("", version: version)
+        let mimeType = attachment.mimeType
+
+        #expect(mimeType == nil, "\(version.description) attachment should return nil for empty MIME type")
+    }
+
+    @Test(
+        "Attachment returns nil for missing mime type",
+        arguments: [FHIRVersion.dstu2, FHIRVersion.r4]
+    )
+    func testMissingMimeType(_ version: FHIRVersion) {
+        let attachment = FHIRAttachmentTestHelper.createAttachment(version: version)
+        let mimeType = attachment.mimeType
+
+        #expect(mimeType == nil, "\(version.description) attachment should return nil for missing MIME type")
+    }
+
+    @Test(
+        "Attachment returns base64 string",
+        arguments: [FHIRVersion.dstu2, FHIRVersion.r4]
+    )
+    func testBase64String(_ version: FHIRVersion) {
+        let testString = "Test content"
+        let attachment = FHIRAttachmentTestHelper.createAttachmentWithData(testString, version: version)
+        let base64String = attachment.base64String
+
+        #expect(base64String == testString, "\(version.description) attachment should return correct base64 string")
+    }
+
+    @Test(
+        "Attachment returns nil for missing base64 string",
+        arguments: [FHIRVersion.dstu2, FHIRVersion.r4]
+    )
+    func testMissingBase64String(_ version: FHIRVersion) {
+        let attachment = FHIRAttachmentTestHelper.createAttachment(version: version)
+        let base64String = attachment.base64String
+
+        #expect(base64String == nil, "\(version.description) attachment should return nil for missing base64 string")
+    }
+
+    @Test(
+        "Attachment encodes content correctly",
+        arguments: [FHIRVersion.dstu2, FHIRVersion.r4]
+    )
+    func testEncodeContent(_ version: FHIRVersion) {
+        let attachment = FHIRAttachmentTestHelper.createAttachment(version: version)
+        let testContent = "This is test content"
+
+        attachment.encode(content: testContent)
+
+        #expect(attachment.base64String == testContent, "\(version.description) attachment should encode content correctly")
+    }
+}

--- a/Tests/SpeziFHIRTests/FHIRAttachment/PDFContentExtractorTests.swift
+++ b/Tests/SpeziFHIRTests/FHIRAttachment/PDFContentExtractorTests.swift
@@ -1,0 +1,149 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+@testable import SpeziFHIR
+import PDFKit
+import Testing
+import UniformTypeIdentifiers
+
+
+@Suite struct PDFContentExtractorTests {
+    @Test("Successfully extracts text from PDF with single page")
+    func testPDFSinglePageTextExtraction() throws {
+        let expectedText = "This is test content for PDF extraction"
+        let mockPage = MockPDFPage(text: expectedText)
+        let mockPDFDocument = MockPDFDocument(pages: [mockPage])
+
+        let pdfProvider = MockPDFDocumentProvider(result: .success(mockPDFDocument))
+        let extractor = PDFContentExtractor(pdfDocumentProvider: pdfProvider)
+
+        let extracted = try extractor.extractContent(from: Data())
+
+        #expect(extracted == expectedText)
+    }
+
+    @Test("Successfully extracts and combines text from multi-page PDF")
+    func testPDFMultiPageTextExtraction() throws {
+        let page1Text = "Page 1 text"
+        let page2Text = "Page 2 text"
+        let page3Text = "Page 3 text"
+
+        let mockPages = [
+            MockPDFPage(text: page1Text),
+            MockPDFPage(text: page2Text),
+            MockPDFPage(text: page3Text)
+        ]
+
+        let mockPDFDocument = MockPDFDocument(pages: mockPages)
+        let mockPDFProvider = MockPDFDocumentProvider(result: .success(mockPDFDocument))
+        let extractor = PDFContentExtractor(pdfDocumentProvider: mockPDFProvider)
+
+        let extracted = try extractor.extractContent(from: Data())
+
+        #expect(extracted.contains(page1Text))
+        #expect(extracted.contains(page2Text))
+        #expect(extracted.contains(page3Text))
+    }
+
+    @Test("Successfully extracts text from PDF with missing pages")
+    func testPDFWithMissingPages() throws {
+        let mockPDFDocument = MockPartialPagesPDFDocument()
+        let mockPDFProvider = MockPDFDocumentProvider(result: .success(mockPDFDocument))
+        let extractor = PDFContentExtractor(pdfDocumentProvider: mockPDFProvider)
+
+        let extracted = try extractor.extractContent(from: Data())
+
+        #expect(extracted.contains("Page 1 content"))
+        #expect(!extracted.contains("Page 2 content"))
+        #expect(extracted.contains("Page 3 content"))
+    }
+
+    @Test("Throws error when PDF parsing fails")
+    func testPDFParsingFailure() throws {
+        let mockPDFProvider = MockPDFDocumentProvider(result: .failure)
+        let extractor = PDFContentExtractor(pdfDocumentProvider: mockPDFProvider)
+
+        do {
+            _ = try extractor.extractContent(from: Data())
+        } catch let error as FHIRAttachmentError {
+            #expect(error == .pdfParsingFailed)
+        }
+    }
+
+    @Test("Correctly identifies compatible content types")
+    func testCompatibleContentTypes() {
+        let extractor = PDFContentExtractor()
+
+        #expect(extractor.isCompatible(with: UTType(mimeType: "application/pdf")!))
+        #expect(!extractor.isCompatible(with: UTType(mimeType: "text/plain")!))
+    }
+}
+
+private struct MockPDFDocumentProvider: PDFDocumentProviding {
+    enum Result {
+        case success(PDFDocument)
+        case failure
+    }
+
+    let result: Result
+
+    func createPDFDocument(from data: Data) -> PDFDocument? {
+        switch result {
+        case .success(let document):
+            return document
+        case .failure:
+            return nil
+        }
+    }
+}
+
+
+private class MockPDFPage: PDFPage {
+    private let mockAttributedString: NSAttributedString
+
+    init(text: String) {
+        self.mockAttributedString = NSAttributedString(string: text)
+        super.init()
+    }
+
+    override var attributedString: NSAttributedString? {
+        return mockAttributedString
+    }
+}
+
+private class MockPDFDocument: PDFDocument {
+    private var mockPages: [MockPDFPage]
+
+    init(pages: [MockPDFPage]) {
+        self.mockPages = pages
+        super.init()
+    }
+
+    override var pageCount: Int {
+        return mockPages.count
+    }
+
+    override func page(at index: Int) -> PDFPage? {
+        guard index >= 0 && index < mockPages.count else {
+            return nil
+        }
+        return mockPages[index]
+    }
+}
+
+private class MockPartialPagesPDFDocument: PDFDocument {
+    override var pageCount: Int { return 3 }
+
+    override func page(at index: Int) -> PDFPage? {
+        if index == 1 {
+            return nil
+        }
+        return MockPDFPage(text: "Page \(index + 1) content")
+    }
+}

--- a/Tests/SpeziFHIRTests/FHIRAttachment/TextContentExtractorTests.swift
+++ b/Tests/SpeziFHIRTests/FHIRAttachment/TextContentExtractorTests.swift
@@ -1,0 +1,50 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+@testable import SpeziFHIR
+import Testing
+import UniformTypeIdentifiers
+
+
+@Suite struct TextContentExtractorTests {
+    private let textExtractor = TextContentExtractor()
+
+    @Test("Successfully extracts content from text data")
+    func testTextExtraction() throws {
+        let textData = "Welcome to SpeziFHIR".data(using: .utf8) ?? Data()
+        let content = try textExtractor.extractContent(from: textData)
+
+        #expect(content == "Welcome to SpeziFHIR")
+    }
+
+    @Test("Throws error when text decoding fails")
+    func testTextDecodingFailure() throws {
+        let invalidData = Data([0xFF, 0xFE, 0xFD])
+
+        do {
+            _ = try textExtractor.extractContent(from: invalidData)
+        } catch let error as FHIRAttachmentError {
+            #expect(error == .textDecodingFailed)
+        }
+    }
+
+    @Test("Correctly identifies compatible content types")
+    func testCompatibleContentTypes() {
+        if let textPlainUTType = UTType(mimeType: "text/plain") {
+            #expect(textExtractor.isCompatible(with: textPlainUTType))
+        }
+        if let textHtmlUTType = UTType(mimeType: "text/html") {
+            #expect(textExtractor.isCompatible(with: textHtmlUTType))
+        }
+        if let applicationPdfUTType = UTType(mimeType: "application/pdf") {
+            #expect(!textExtractor.isCompatible(with: applicationPdfUTType))
+        }
+    }
+}
+

--- a/Tests/SpeziFHIRTests/FHIRAttachment/TextContentExtractorTests.swift
+++ b/Tests/SpeziFHIRTests/FHIRAttachment/TextContentExtractorTests.swift
@@ -12,7 +12,8 @@ import Testing
 import UniformTypeIdentifiers
 
 
-@Suite struct TextContentExtractorTests {
+@Suite
+struct TextContentExtractorTests {
     private let textExtractor = TextContentExtractor()
 
     @Test("Successfully extracts content from text data")
@@ -38,13 +39,20 @@ import UniformTypeIdentifiers
     func testCompatibleContentTypes() {
         if let textPlainUTType = UTType(mimeType: "text/plain") {
             #expect(textExtractor.isCompatible(with: textPlainUTType))
+        } else {
+            Issue.record("Failed to create UTType for text/plain")
         }
+
         if let textHtmlUTType = UTType(mimeType: "text/html") {
             #expect(textExtractor.isCompatible(with: textHtmlUTType))
+        } else {
+            Issue.record("Failed to create UTType for text/html")
         }
+
         if let applicationPdfUTType = UTType(mimeType: "application/pdf") {
             #expect(!textExtractor.isCompatible(with: applicationPdfUTType))
+        } else {
+            Issue.record("Failed to create UTType for application/pdf")
         }
     }
 }
-

--- a/Tests/SpeziFHIRTests/FHIRResourceTests/FHIRResourceDSTU2Mocks.swift
+++ b/Tests/SpeziFHIRTests/FHIRResourceTests/FHIRResourceDSTU2Mocks.swift
@@ -10,7 +10,7 @@ import Foundation
 import ModelsDSTU2
 
 
-enum ModelsDSTU2Mocks {
+enum ModelsDSTU2Mocks { // swiftlint:disable:this type_body_length
     static func createAllergyIntolerance() -> ModelsDSTU2.AllergyIntolerance {
         ModelsDSTU2.AllergyIntolerance(
             id: "allergy-intolerance-id".asFHIRStringPrimitive(),
@@ -204,6 +204,115 @@ enum ModelsDSTU2Mocks {
             performer: Reference(id: "performer-id".asFHIRStringPrimitive()),
             status: FHIRPrimitive(.completed),
             subject: Reference(id: "patient-id".asFHIRStringPrimitive())
+        )
+    }
+
+    static func createAttachment(
+        id: String,
+        title: String,
+        contentType: String,
+        content: String,
+        creation: Date? = nil
+    ) throws -> ModelsDSTU2.Attachment {
+        let attachment = ModelsDSTU2.Attachment(
+            contentType: FHIRPrimitive(stringLiteral: contentType),
+            data: FHIRPrimitive(ModelsDSTU2.Base64Binary(content)),
+            id: id.asFHIRStringPrimitive(),
+            title: FHIRPrimitive(ModelsDSTU2.FHIRString(title))
+        )
+
+        if let creation {
+            attachment.creation = FHIRPrimitive(try DateTime(date: creation))
+        }
+
+        return attachment
+    }
+
+    static func createDocumentReference(
+        id: String = "document-reference-id",
+        status: ModelsDSTU2.DocumentReferenceStatus = .current,
+        type: ModelsDSTU2.CodeableConcept? = nil,
+        attachments: [ModelsDSTU2.Attachment] = [],
+        created: Date? = nil
+    ) throws -> ModelsDSTU2.DocumentReference {
+        let documentType = type ?? CodeableConcept(
+            coding: [
+                Coding(
+                    code: "34108-1".asFHIRStringPrimitive(),
+                    display: "Outpatient Note".asFHIRStringPrimitive(),
+                    system: "http://mock.org".asFHIRURIPrimitive()
+                )
+            ]
+        )
+
+        let contentItems = attachments.map { attachment in
+            ModelsDSTU2.DocumentReferenceContent(attachment: attachment)
+        }
+
+        let indexedInstant = FHIRPrimitive(try Instant(date: Date()))
+
+        let documentReference = ModelsDSTU2.DocumentReference(
+            content: contentItems,
+            indexed: indexedInstant,
+            status: FHIRPrimitive(status),
+            type: documentType
+        )
+
+        documentReference.id = id.asFHIRStringPrimitive()
+
+        if let created {
+            documentReference.created = FHIRPrimitive(try DateTime(date: created))
+        }
+
+        return documentReference
+    }
+
+    static func createTextAttachment(
+        id: String = "text-attachment-id",
+        title: String = "Text Attachment",
+        creationDate: Date? = nil
+    ) throws -> ModelsDSTU2.Attachment {
+        // This is a minimal base64-encoded text with the text "Welcome to SpeziFHIR"
+        let textBase64 = "V2VsY29tZSB0byBTcGV6aUZISVI="
+
+        return try createAttachment(
+            id: id,
+            title: title,
+            contentType: "text/plain",
+            content: textBase64,
+            creation: creationDate
+        )
+    }
+
+    static func createPDFAttachment(
+        id: String = "pdf-attachment-id",
+        title: String = "PDF Attachment",
+        creation: Date? = nil
+    ) throws -> ModelsDSTU2.Attachment {
+        // This is a minimal base64-encoded PDF with the text "PDF: Welcome to SpeziFHIR"
+        // swiftlint:disable:next line_length
+        let pdfBase64 = "JVBERi0xLjQKMSAwIG9iago8PCAvVHlwZSAvQ2F0YWxvZyAvUGFnZXMgMiAwIFIgPj4KZW5kb2JqCjIgMCBvYmoKPDwgL1R5cGUgL1BhZ2VzIC9LaWRzIFszIDAgUl0gL0NvdW50IDEgPj4KZW5kb2JqCjMgMCBvYmoKPDwgL1R5cGUgL1BhZ2UgL1BhcmVudCAyIDAgUiAvTWVkaWFCb3ggWzAgMCA2MTIgNzkyXSAvUmVzb3VyY2VzIDw8IC9Gb250IDw8IC9GMSA0IDAgUiA+PiA+PiAvQ29udGVudHMgNSAwIFIgPj4KZW5kb2JqCjQgMCBvYmoKPDwgL1R5cGUgL0ZvbnQgL1N1YnR5cGUgL1R5cGUxIC9CYXNlRm9udCAvSGVsdmV0aWNhID4+CmVuZG9iago1IDAgb2JqCjw8IC9MZW5ndGggNDQgPj4Kc3RyZWFtCkJUCi9GMSAxNiBUZgo1MCA3MDAgVGQKKFBERjogV2VsY29tZSB0byBTcGV6aUZISVIpIFRqCkVUCmVuZHN0cmVhbQplbmRvYmoKeHJlZgowIDYKMDAwMDAwMDAwMCA2NTUzNSBmCjAwMDAwMDAwMDkgMDAwMDAgbgowMDAwMDAwMDU4IDAwMDAwIG4KMDAwMDAwMDExNSAwMDAwMCBuCjAwMDAwMDAyMjkgMDAwMDAgbgowMDAwMDAwMjk1IDAwMDAwIG4KdHJhaWxlcgo8PCAvU2l6ZSA2IC9Sb290IDEgMCBSID4+CnN0YXJ0eHJlZgozOTEKJSVFT0Y="
+
+        return try createAttachment(
+            id: id,
+            title: title,
+            contentType: "application/pdf",
+            content: pdfBase64,
+            creation: creation
+        )
+    }
+
+    static func createMixedDocumentReference(
+        id: String = "mixed-document-id",
+        created: Date? = nil
+    ) throws -> ModelsDSTU2.DocumentReference {
+        let textAttachment = try createTextAttachment()
+        let pdfAttachment = try createPDFAttachment()
+
+        return try createDocumentReference(
+            id: id,
+            attachments: [textAttachment, pdfAttachment],
+            created: created
         )
     }
 }

--- a/Tests/SpeziFHIRTests/FHIRResourceTests/FHIRResourceR4Mocks.swift
+++ b/Tests/SpeziFHIRTests/FHIRResourceTests/FHIRResourceR4Mocks.swift
@@ -362,4 +362,117 @@ enum ModelsR4Mocks { // swiftlint:disable:this type_body_length
 
         return bundle
     }
+
+    static func createAttachment(
+        id: String,
+        title: String,
+        contentType: String,
+        content: String,
+        creationDate: Date? = nil
+    ) throws -> ModelsR4.Attachment {
+        let attachment = ModelsR4.Attachment(
+            contentType: FHIRPrimitive(stringLiteral: contentType),
+            data: FHIRPrimitive(ModelsR4.Base64Binary(content)),
+            id: id.asFHIRStringPrimitive(),
+            title: FHIRPrimitive(ModelsR4.FHIRString(title))
+        )
+
+        if let creationDate {
+            attachment.creation = FHIRPrimitive(try DateTime(date: creationDate))
+        }
+
+        return attachment
+    }
+
+    static func createDocumentReference(
+        id: String = "document-reference-id",
+        status: ModelsR4.DocumentReferenceStatus = .current,
+        type: ModelsR4.CodeableConcept? = nil,
+        attachments: [ModelsR4.Attachment] = [],
+        date: Date? = nil
+    ) throws -> ModelsR4.DocumentReference {
+        let documentType = type ?? CodeableConcept(
+            coding: [
+                Coding(
+                    code: "34108-1".asFHIRStringPrimitive(),
+                    display: "Outpatient Note".asFHIRStringPrimitive(),
+                    system: "http://mock.org".asFHIRURIPrimitive()
+                )
+            ]
+        )
+
+
+        let contentItems = attachments.map { attachment in
+            ModelsR4.DocumentReferenceContent(attachment: attachment)
+        }
+
+        let documentReference = ModelsR4.DocumentReference(
+            content: contentItems,
+            status: FHIRPrimitive(status),
+            type: documentType
+        )
+
+        documentReference.id = id.asFHIRStringPrimitive()
+
+        if let date {
+            documentReference.date = FHIRPrimitive<Instant>(try? Instant(date: date))
+        }
+
+        return documentReference
+    }
+
+    static func createTextAttachment(
+        id: String = "text-attachment-id",
+        title: String = "Text Attachment",
+        creationDate: Date? = nil
+    ) throws -> ModelsR4.Attachment {
+        // This is a minimal base64-encoded text with the text "Welcome to SpeziFHIR"
+        let textBase64 = "V2VsY29tZSB0byBTcGV6aUZISVI="
+
+        return try createAttachment(
+            id: id,
+            title: title,
+            contentType: "text/plain",
+            content: textBase64,
+            creationDate: creationDate
+        )
+    }
+
+    static func createPDFAttachment(
+        id: String = "pdf-attachment-id",
+        title: String = "PDF Attachment",
+        creationDate: Date? = nil
+    ) throws -> ModelsR4.Attachment {
+        // This is a minimal base64-encoded PDF with the text "PDF: Welcome to SpeziFHIR"
+        // swiftlint:disable:next line_length
+        let pdfBase64 = "JVBERi0xLjQKMSAwIG9iago8PCAvVHlwZSAvQ2F0YWxvZyAvUGFnZXMgMiAwIFIgPj4KZW5kb2JqCjIgMCBvYmoKPDwgL1R5cGUgL1BhZ2VzIC9LaWRzIFszIDAgUl0gL0NvdW50IDEgPj4KZW5kb2JqCjMgMCBvYmoKPDwgL1R5cGUgL1BhZ2UgL1BhcmVudCAyIDAgUiAvTWVkaWFCb3ggWzAgMCA2MTIgNzkyXSAvUmVzb3VyY2VzIDw8IC9Gb250IDw8IC9GMSA0IDAgUiA+PiA+PiAvQ29udGVudHMgNSAwIFIgPj4KZW5kb2JqCjQgMCBvYmoKPDwgL1R5cGUgL0ZvbnQgL1N1YnR5cGUgL1R5cGUxIC9CYXNlRm9udCAvSGVsdmV0aWNhID4+CmVuZG9iago1IDAgb2JqCjw8IC9MZW5ndGggNDQgPj4Kc3RyZWFtCkJUCi9GMSAxNiBUZgo1MCA3MDAgVGQKKFBERjogV2VsY29tZSB0byBTcGV6aUZISVIpIFRqCkVUCmVuZHN0cmVhbQplbmRvYmoKeHJlZgowIDYKMDAwMDAwMDAwMCA2NTUzNSBmCjAwMDAwMDAwMDkgMDAwMDAgbgowMDAwMDAwMDU4IDAwMDAwIG4KMDAwMDAwMDExNSAwMDAwMCBuCjAwMDAwMDAyMjkgMDAwMDAgbgowMDAwMDAwMjk1IDAwMDAwIG4KdHJhaWxlcgo8PCAvU2l6ZSA2IC9Sb290IDEgMCBSID4+CnN0YXJ0eHJlZgozOTEKJSVFT0Y="
+
+        return try createAttachment(
+            id: id,
+            title: title,
+            contentType: "application/pdf",
+            content: pdfBase64,
+            creationDate: creationDate
+        )
+    }
+
+    static func createMixedDocumentReference(
+        id: String = "mixed-document-id",
+        date: Date? = nil
+    ) throws -> ModelsR4.DocumentReference {
+        let textAttachment = try createAttachment(
+            id: "text-attachment-id",
+            title: "Text Component",
+            contentType: "text/plain",
+            content: "V2VsY29tZSB0byBTcGV6aUZISVI="
+        )
+
+        let pdfAttachment = try createPDFAttachment()
+
+        return try createDocumentReference(
+            id: id,
+            attachments: [textAttachment, pdfAttachment],
+            date: date
+        )
+    }
 }

--- a/Tests/SpeziFHIRTests/FHIRResourceTests/FHIRResourceStringifyTests.swift
+++ b/Tests/SpeziFHIRTests/FHIRResourceTests/FHIRResourceStringifyTests.swift
@@ -1,0 +1,117 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import ModelsDSTU2
+import ModelsR4
+@testable import SpeziFHIR
+import Testing
+import UniformTypeIdentifiers
+
+@Suite("FHIR Resource Attachment Stringification")
+struct FHIRResourceStringifyTests {
+    private let service = FHIRAttachmentService()
+
+    // MARK: - R4 Tests
+
+    @Test("R4 text attachment should be properly stringified")
+    func testR4TextAttachmentStringification() throws {
+        let attachment = try ModelsR4Mocks.createTextAttachment()
+        let docRef = try ModelsR4Mocks.createDocumentReference(attachments: [attachment])
+        let resource = FHIRResource(versionedResource: .r4(docRef), displayName: "Text Document")
+
+        let originalBase64 = attachment.base64String
+
+        try resource.stringifyAttachements(using: service)
+
+        let transformedContent = attachment.base64String
+
+        #expect(transformedContent != nil)
+        #expect(transformedContent != originalBase64, "Content should be transformed")
+        #expect(transformedContent == "Welcome to SpeziFHIR", "Content should now be human-readable")
+    }
+
+    @Test("R4 PDF attachment should extract text content")
+    func testR4PDFAttachmentStringification() throws {
+        let pdfAttachment = try ModelsR4Mocks.createPDFAttachment()
+        let docRef = try ModelsR4Mocks.createDocumentReference(attachments: [pdfAttachment])
+        let resource = FHIRResource(versionedResource: .r4(docRef), displayName: "PDF Document")
+
+        let originalBase64 = pdfAttachment.base64String
+
+        try resource.stringifyAttachements(using: service)
+
+        let transformedContent = pdfAttachment.base64String
+
+        #expect(transformedContent != nil)
+        #expect(transformedContent != originalBase64, "Content should be transformed")
+        #expect(transformedContent == "PDF: Welcome to SpeziFHIR", "Extracted content should contain PDF text")
+    }
+
+    @Test("R4 document with mixed attachments should process all attachments")
+    func testR4MixedAttachmentsProcessing() throws {
+        let docRef = try ModelsR4Mocks.createMixedDocumentReference()
+        let resource = FHIRResource(versionedResource: .r4(docRef), displayName: "Mixed Document")
+
+        let originalContents = docRef.content.compactMap { $0.attachment.base64String }
+
+        try resource.stringifyAttachements(using: service)
+
+        let transformedContents = docRef.content.compactMap { $0.attachment.base64String }
+
+        for (index, originalContent) in originalContents.enumerated() {
+            #expect(transformedContents[index] != originalContent, "Attachment \(index) should be transformed")
+        }
+    }
+
+    @Test("Empty document reference should process no attachments")
+    func testEmptyDocumentReferenceProcessesNoAttachments() throws {
+        let docRef = try ModelsR4Mocks.createDocumentReference(attachments: [])
+        let resource = FHIRResource(versionedResource: .r4(docRef), displayName: "Empty Document")
+
+        try resource.stringifyAttachements(using: service)
+
+        #expect(docRef.content.isEmpty, "Content array should remain empty")
+    }
+
+    // MARK: - DSTU2 Tests
+
+    @Test("DSTU2 text attachment should be properly stringified")
+    func testDSTU2TextAttachmentStringification() throws {
+        let attachment = try ModelsDSTU2Mocks.createTextAttachment()
+        let docRef = try ModelsDSTU2Mocks.createDocumentReference(attachments: [attachment])
+        let resource = FHIRResource(versionedResource: .dstu2(docRef), displayName: "DSTU2 Document")
+
+        let originalBase64 = attachment.base64String
+
+        try resource.stringifyAttachements(using: service)
+
+        let transformedContent = attachment.base64String
+        #expect(transformedContent != nil)
+        #expect(transformedContent != originalBase64, "Content should be transformed")
+        #expect(transformedContent == "Welcome to SpeziFHIR", "Content should now be human-readable")
+    }
+
+    @Test("DSTU2 PDF attachment should extract text content")
+    func testDSTU2PDFAttachmentStringification() throws {
+        // Arrange - Create a document with a PDF attachment
+        let pdfAttachment = try ModelsDSTU2Mocks.createPDFAttachment()
+        let docRef = try ModelsDSTU2Mocks.createDocumentReference(attachments: [pdfAttachment])
+        let resource = FHIRResource(versionedResource: .dstu2(docRef), displayName: "DSTU2 PDF Document")
+
+        let originalBase64 = pdfAttachment.base64String
+
+        try resource.stringifyAttachements(using: service)
+
+        let transformedContent = pdfAttachment.base64String
+        #expect(transformedContent != nil)
+        #expect(transformedContent != originalBase64, "Content should be transformed")
+
+        // The PDF content should now contain "PDF: Welcome to SpeziFHIR" text from the mock PDF
+        #expect(transformedContent == "PDF: Welcome to SpeziFHIR", "Extracted content should contain PDF text")
+    }
+}


### PR DESCRIPTION
# Improve Clinical Notes Extraction and Parsing Architecture

## :gear: Release Notes
- I've refactored how attachments are processed by separating the responsibilities of the previous implementation. The `base64Data` property has been replaced with: a read-only `base64String` property and an `encode(content:)` method.

- Fixed inconsistent naming throughout the codebase. Fixed some typos.

- Content extraction now uses a modular system of extractors, making it easy to add support for additional file types.

- Added more specific error types.

## Breaking Changes

A few necessary breaking changes:
- Protocol renamed to `FHIRAttachment` 
- `base64Data` property renamed to `base64String`
- More specific error types replace generic ones
- Updated method signatures for clarity

## :books: Documentation
Documentation is added in code and throughout public methods and properties.


## :white_check_mark: Testing
✅ All components are tested, near-100% test coverage.


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
