### PR TITLE
Implement date fallback strategy for Observations

### DIFF
--- a/Sources/SpeziFHIR/FHIRResource/FHIRResource.swift
+++ b/Sources/SpeziFHIR/FHIRResource/FHIRResource.swift
@@ -80,7 +80,12 @@ public struct FHIRResource: Identifiable, Hashable {
             case let medicationAdministration as ModelsR4.MedicationAdministration:
                 return medicationAdministration.effective.date
             case let observation as ModelsR4.Observation:
-                return try? observation.issued?.value?.asNSDate()
+                if let issuedDate = observation.issued {
+                    return try? issuedDate.value?.asNSDate()
+                } else if case let .dateTime(effectiveDate) = observation.effective {
+                    return try? effectiveDate.value?.asNSDate()
+                }
+                return nil
             case let procedure as ModelsR4.Procedure:
                 return procedure.performed?.date
             case let patient as ModelsR4.Patient:
@@ -95,7 +100,12 @@ public struct FHIRResource: Identifiable, Hashable {
         case let .dstu2(resource):
             switch resource {
             case let observation as ModelsDSTU2.Observation:
-                return try? observation.issued?.value?.asNSDate()
+                if let issuedDate = observation.issued {
+                    return try? issuedDate.value?.asNSDate()
+                } else if case let .dateTime(effectiveDate) = observation.effective {
+                    return try? effectiveDate.value?.asNSDate()
+                }
+                return nil
             case let medicationOrder as ModelsDSTU2.MedicationOrder:
                 return try? medicationOrder.dateWritten?.value?.asNSDate()
             case let medicationStatement as ModelsDSTU2.MedicationStatement:

--- a/Tests/SpeziFHIRTests/FHIRResourceTests/FHIRResourceDSTU2Mocks.swift
+++ b/Tests/SpeziFHIRTests/FHIRResourceTests/FHIRResourceDSTU2Mocks.swift
@@ -46,7 +46,7 @@ enum ModelsDSTU2Mocks { // swiftlint:disable:this type_body_length
         )
     }
 
-    static func createObservation(date: Date? = nil) throws -> ModelsDSTU2.Observation {
+    static func createObservation(issuedDate: Date? = nil, effectiveDate: Date? = nil) throws -> ModelsDSTU2.Observation {
         let observation = ModelsDSTU2.Observation(
             code: CodeableConcept(
                 coding: [
@@ -56,8 +56,10 @@ enum ModelsDSTU2Mocks { // swiftlint:disable:this type_body_length
             id: "observation-id".asFHIRStringPrimitive(),
             status: FHIRPrimitive(.final)
         )
-        if let date = date {
-            observation.issued = FHIRPrimitive(try Instant(date: date))
+        if let issuedDate {
+            observation.issued = FHIRPrimitive(try Instant(date: issuedDate))
+        } else if let effectiveDate {
+            observation.effective = .dateTime(FHIRPrimitive(try DateTime(date: effectiveDate)))
         }
         return observation
     }

--- a/Tests/SpeziFHIRTests/FHIRResourceTests/FHIRResourceR4Mocks.swift
+++ b/Tests/SpeziFHIRTests/FHIRResourceTests/FHIRResourceR4Mocks.swift
@@ -276,14 +276,16 @@ enum ModelsR4Mocks { // swiftlint:disable:this type_body_length
         )
     }
     
-    static func createObservation(date: Date? = nil) throws -> ModelsR4.Observation {
+    static func createObservation(issuedDate: Date? = nil, effectiveDate: Date? = nil) throws -> ModelsR4.Observation {
         let observation = ModelsR4.Observation(
             code: CodeableConcept(coding: [Coding(code: "code".asFHIRStringPrimitive())]),
             id: "observation-id".asFHIRStringPrimitive(),
             status: FHIRPrimitive(.final)
         )
-        if let date = date {
-            observation.issued = FHIRPrimitive(try Instant(date: date))
+        if let issuedDate {
+            observation.issued = FHIRPrimitive(try Instant(date: issuedDate))
+        } else if let effectiveDate {
+            observation.effective = .dateTime(FHIRPrimitive(try DateTime(date: effectiveDate)))
         }
         return observation
     }

--- a/Tests/SpeziFHIRTests/FHIRResourceTests/FHIRResourceTests.swift
+++ b/Tests/SpeziFHIRTests/FHIRResourceTests/FHIRResourceTests.swift
@@ -29,8 +29,8 @@ class FHIRResourceTests: XCTestCase {
 
 
     func testModelsR4ResourceInitialization() throws {
-        let mockObservation = try ModelsR4Mocks.createObservation(date: Self.testDate)
-        
+        let mockObservation = try ModelsR4Mocks.createObservation(issuedDate: Self.testDate)
+
         let resource = FHIRResource(
             resource: mockObservation,
             displayName: "Test Observation"
@@ -42,8 +42,8 @@ class FHIRResourceTests: XCTestCase {
     }
     
     func testModelsDSTU2ResourceInitialization() throws {
-        let mockObservation = try ModelsDSTU2Mocks.createObservation(date: Self.testDate)
-        
+        let mockObservation = try ModelsDSTU2Mocks.createObservation(issuedDate: Self.testDate)
+
         let resource = FHIRResource(
             resource: mockObservation,
             displayName: "Test Observation"
@@ -68,7 +68,8 @@ class FHIRResourceTests: XCTestCase {
             (ModelsR4Mocks.createImmunization(date: Self.testDate), "Immunization"),
             (ModelsR4Mocks.createMedicationRequest(date: Self.testDate), "MedicationRequest"),
             (ModelsR4Mocks.createMedicationAdministration(date: Self.testDate), "MedicationAdministration"),
-            (ModelsR4Mocks.createObservation(date: Self.testDate), "Observation"),
+            (ModelsR4Mocks.createObservation(issuedDate: Self.testDate), "Observation with issued date"),
+            (ModelsR4Mocks.createObservation(effectiveDate: Self.testDate), "Observation with effective date"),
             (ModelsR4Mocks.createProcedure(date: Self.testDate), "Procedure"),
             (ModelsR4Mocks.createPatient(date: Self.testDate), "Patient"),
             (ModelsR4Mocks.createProvenance(date: Self.testDate), "Provenance"),
@@ -91,7 +92,8 @@ class FHIRResourceTests: XCTestCase {
     
     func testModelsDSTU2ResourceDates() throws {
         let modelsDSTU2Resources: [(ModelsDSTU2.Resource, String)] = try [
-            (ModelsDSTU2Mocks.createObservation(date: Self.testDate), "Observation"),
+            (ModelsDSTU2Mocks.createObservation(issuedDate: Self.testDate), "Observation with issued date"),
+            (ModelsDSTU2Mocks.createObservation(effectiveDate: Self.testDate), "Observation with effective date"),
             (ModelsDSTU2Mocks.createMedicationOrder(date: Self.testDate), "MedicationOrder"),
             (ModelsDSTU2Mocks.createMedicationStatement(date: Self.testDate), "MedicationStatement"),
             (ModelsDSTU2Mocks.createCondition(date: Self.testDate), "Condition"),


### PR DESCRIPTION
# Implement date fallback strategy for Observations

## :recycle: Current situation & Problem
Observation resources sometimes lack an issued date, causing the system to return nil for their date property. This creates a bad user experience in chronologically-sorted resource lists, as these observations are pushed to the bottom of lists due to missing date information, despite often containing an alternative effective date that could provide meaningful context.

## :gear: Release Notes
When extracting dates from Observation resources, now properly supports using the effective date as a fallback when issued date is missing.

## :books: Documentation
N/A

## :white_check_mark: Testing
Added new unit tests covering issued date and the effective date.

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
