### PR TITLE
Improve `copy` with per-resource locking

### DIFF
--- a/Sources/SpeziFHIR/FHIRResource/FHIRResource+Copy.swift
+++ b/Sources/SpeziFHIR/FHIRResource/FHIRResource+Copy.swift
@@ -12,9 +12,9 @@ import ModelsR4
 
 
 extension FHIRResource {
-    private static let encoder = PropertyListEncoder()
+    private static let encoder = JSONEncoder()
 
-    private static let decoder = PropertyListDecoder()
+    private static let decoder = JSONDecoder()
 
     private static let lockManager = FHIRResourceLockManager()
 

--- a/Sources/SpeziFHIR/FHIRResource/FHIRResource+Copy.swift
+++ b/Sources/SpeziFHIR/FHIRResource/FHIRResource+Copy.swift
@@ -12,17 +12,54 @@ import ModelsR4
 
 
 extension FHIRResource {
-    /// Creates an (expensive) copy of the underlying FHIR reference types by encoding and decoding the FHIR resource in JSON.
-    ///
-    /// - Warning: The computational complexity of creating a copy should only be used in when creating a new copy is strictly necessary.
-    public func copy() throws -> Self {
+    private static let encoder = PropertyListEncoder()
+
+    private static let decoder = PropertyListDecoder()
+
+    private static let lockManager = FHIRResourceLockManager()
+
+    private var resourceIdentityKey: String {
+        let resourceId: String
+
         switch versionedResource {
-        case let .r4(r4Resource):
-            let resource = try JSONDecoder().decode(ModelsR4.ResourceProxy.self, from: try JSONEncoder().encode(r4Resource)).get()
-            return .init(resource: resource, displayName: displayName)
-        case let .dstu2(dstu2Resource):
-            let resource = try JSONDecoder().decode(ModelsDSTU2.ResourceProxy.self, from: try JSONEncoder().encode(dstu2Resource)).get()
-            return .init(resource: resource, displayName: displayName)
+        case .r4(let r4Resource):
+            resourceId = r4Resource.id?.value?.string ?? UUID().uuidString
+        case .dstu2(let dstu2Resource):
+            resourceId = dstu2Resource.id?.value?.string ?? UUID().uuidString
+        }
+
+        let resourceType = String(describing: type(of: versionedResource))
+        return "\(resourceType)_\(resourceId)"
+    }
+
+    /// Creates a thread-safe deep copy of the FHIR resource using per-resource locking.
+    ///
+    /// This implementation uses a unique lock for each resource identity, allowing multiple
+    /// different resources to be copied concurrently.
+    ///
+    /// - Returns: A deep copy of this FHIR resource with identical content but separate memory allocation
+    /// - Throws: An error if JSON serialization or deserialization fails
+    ///
+    /// - Warning: While thread-safe, this method is still computationally expensive.
+    ///            Consider using it only when creating a new copy is strictly necessary.
+    public func copy() throws -> Self {
+        let localVersionedResource = versionedResource
+        let localDisplayName = displayName
+
+        let identityKey = resourceIdentityKey
+
+        return try Self.lockManager.withLock(for: identityKey) {
+            switch localVersionedResource {
+            case let .r4(r4Resource):
+                let encodedData = try Self.encoder.encode(r4Resource)
+                let resource = try Self.decoder.decode(ModelsR4.ResourceProxy.self, from: encodedData).get()
+                return .init(resource: resource, displayName: localDisplayName)
+
+            case let .dstu2(dstu2Resource):
+                let encodedData = try Self.encoder.encode(dstu2Resource)
+                let resource = try Self.decoder.decode(ModelsDSTU2.ResourceProxy.self, from: encodedData).get()
+                return .init(resource: resource, displayName: localDisplayName)
+            }
         }
     }
 }

--- a/Sources/SpeziFHIR/FHIRResource/FHIRResourceLockManager.swift
+++ b/Sources/SpeziFHIR/FHIRResource/FHIRResourceLockManager.swift
@@ -1,0 +1,43 @@
+//
+// This source file is part of the Stanford Spezi open source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+final class FHIRResourceLockManager: @unchecked Sendable {
+    private var locks = [String: NSRecursiveLock]()
+    private let lockQueue = DispatchQueue(label: "com.fhir.resource.lockmanager", attributes: .concurrent)
+
+    func withLock<T>(for identityKey: String, execute block: () throws -> T) throws -> T {
+        let lock = getLock(for: identityKey)
+
+        lock.lock()
+        defer { lock.unlock() }
+
+        return try block()
+    }
+
+    private func getLock(for identityKey: String) -> NSRecursiveLock {
+        let existingLock = lockQueue.sync {
+            locks[identityKey]
+        }
+
+        if let existingLock = existingLock {
+            return existingLock
+        }
+
+        return lockQueue.sync(flags: .barrier) {
+            if let existingLock = locks[identityKey] {
+                return existingLock
+            }
+
+            let newLock = NSRecursiveLock()
+            locks[identityKey] = newLock
+            return newLock
+        }
+    }
+}

--- a/Tests/SpeziFHIRTests/FHIRResourceTests/FHIRResourceCopyTests.swift
+++ b/Tests/SpeziFHIRTests/FHIRResourceTests/FHIRResourceCopyTests.swift
@@ -1,0 +1,103 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import ModelsDSTU2
+import ModelsR4
+@testable import SpeziFHIR
+import Testing
+
+
+@Suite("FHIRResource Copy Tests")
+struct FHIRResourceCopyTests {
+    @Test("FHIRResource - Copy Complex R4 Resource")
+    func testCopyComplexR4Resource() throws {
+        let r4DocumentReference = try ModelsR4Mocks.createMixedDocumentReference()
+        let r4Resource = FHIRResource(resource: r4DocumentReference, displayName: "Complex R4 Document")
+
+        let copiedR4Resource = try r4Resource.copy()
+
+        #expect(r4Resource.displayName == copiedR4Resource.displayName, "DisplayName was not copied correctly")
+
+        let originalDoc: ModelsR4.DocumentReference? = if case let (.r4(res)) = r4Resource.versionedResource {
+            res as? ModelsR4.DocumentReference
+        } else {
+            nil
+        }
+
+        let copiedDoc: ModelsR4.DocumentReference? = if case let (.r4(res)) = copiedR4Resource.versionedResource {
+            res as? ModelsR4.DocumentReference
+        } else {
+            nil
+        }
+
+        #expect(originalDoc?.id?.value?.string == copiedDoc?.id?.value?.string, "ID was not copied correctly")
+
+        #expect(originalDoc?.content.count == 2, "Original should have 2 attachments")
+        #expect(copiedDoc?.content.count == 2, "Copy should have 2 attachments")
+
+        if let mutableCopy = copiedDoc, let originalAttachment = originalDoc?.content.first?.attachment {
+            if var title = mutableCopy.content.first?.attachment.title {
+                title.value = ModelsR4.FHIRString("Modified Title")
+            }
+
+            #expect(originalAttachment.title?.value?.string != "Modified Title", "Modifying copy should not affect original")
+        }
+    }
+
+    @Test("FHIRResource - Copy Concurrency")
+    func testCopyConcurrency() throws {
+        var resources: [FHIRResource] = [
+            FHIRResource(resource: try ModelsR4Mocks.createPatient(), displayName: "Patient"),
+            FHIRResource(resource: try ModelsR4Mocks.createCondition(), displayName: "Condition"),
+            FHIRResource(resource: try ModelsR4Mocks.createObservation(), displayName: "Observation"),
+            FHIRResource(resource: try ModelsR4Mocks.createDocumentReference(), displayName: "DocumentReference"),
+            FHIRResource(resource: try ModelsR4Mocks.createImmunization(), displayName: "Immunization"),
+            FHIRResource(resource: ModelsDSTU2Mocks.createAllergyIntolerance(), displayName: "AllergyIntolerance"),
+            FHIRResource(resource: ModelsDSTU2Mocks.createDiagnosticOrder(), displayName: "DiagnosticOrder"),
+            FHIRResource(resource: try ModelsDSTU2Mocks.createDiagnosticReport(), displayName: "DiagnosticReport"),
+            FHIRResource(resource: try ModelsDSTU2Mocks.createObservation(), displayName: "Observation"),
+            FHIRResource(resource: ModelsDSTU2Mocks.createImmunization(), displayName: "Immunization")
+        ]
+
+        let group = DispatchGroup()
+        let queue = DispatchQueue(label: "com.test.concurrent", attributes: .concurrent)
+
+        let lock = NSLock()
+
+        var copiedResourcesDict = [Int: FHIRResource]()
+
+        for (index, resource) in resources.enumerated() {
+            group.enter()
+            queue.async {
+                do {
+                    let copiedResource = try resource.copy()
+                    lock.lock()
+                    copiedResourcesDict[index] = copiedResource
+                    lock.unlock()
+
+                    group.leave()
+                } catch {
+                    Issue.record("Failed to copy resource \(resource.displayName): \(error)")
+                    group.leave()
+                }
+            }
+        }
+
+        let timeoutResult = group.wait(timeout: .now() + 5.0)
+        #expect(timeoutResult == .success, "Copy operations timed out")
+
+        for (index, original) in resources.enumerated() {
+            if let copy = copiedResourcesDict[index] {
+                #expect(original.displayName == copy.displayName, "Copy at index \(index) has incorrect displayName: expected \(original.displayName), got \(copy.displayName)")
+            } else {
+                Issue.record("Missing copied resource at index \(index)")
+            }
+        }
+    }
+}

--- a/Tests/SpeziFHIRTests/FHIRResourceTests/FHIRResourceCopyTests.swift
+++ b/Tests/SpeziFHIRTests/FHIRResourceTests/FHIRResourceCopyTests.swift
@@ -52,7 +52,7 @@ struct FHIRResourceCopyTests {
 
     @Test("FHIRResource - Copy Concurrency")
     func testCopyConcurrency() throws {
-        var resources: [FHIRResource] = [
+        let resources: [FHIRResource] = [
             FHIRResource(resource: try ModelsR4Mocks.createPatient(), displayName: "Patient"),
             FHIRResource(resource: try ModelsR4Mocks.createCondition(), displayName: "Condition"),
             FHIRResource(resource: try ModelsR4Mocks.createObservation(), displayName: "Observation"),

--- a/Tests/SpeziFHIRTests/FHIRResourceTests/FHIRResourceLockManagerTests.swift
+++ b/Tests/SpeziFHIRTests/FHIRResourceTests/FHIRResourceLockManagerTests.swift
@@ -1,0 +1,295 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+@testable import SpeziFHIR
+import Testing
+
+@Suite
+struct FHIRResourceLockManagerTests {
+    private enum Constants {
+        static let shortDelay: TimeInterval = 0.001
+        static let longDelay: TimeInterval = 0.01
+        static let shortTimeout: TimeInterval = 1.0
+        static let longTimeout: TimeInterval = 10.0
+        static let iterations = 100
+        static let standardIdentityKey = "test-resource-1"
+        static let multipleIdentityKeys = [
+            "test-resource-1",
+            "test-resource-2",
+            "test-resource-3",
+            "test-resource-4",
+            "test-resource-5"
+        ]
+    }
+
+    private let lockManager = FHIRResourceLockManager()
+
+    @Test("FHIRResourceLockManager - Lock Protection Test")
+    func testLockProtection() throws {
+        let identityKey = Constants.standardIdentityKey
+
+        let orderTracker = UnsafeOrderTracker()
+        let counter = UnsafeCounter()
+
+        let group = DispatchGroup()
+        let queue = DispatchQueue(label: "com.test.concurrent", attributes: .concurrent)
+
+        group.enter()
+        queue.async {
+            do {
+                try lockManager.withLock(for: identityKey) {
+                    orderTracker.append(1)
+                    counter.increment(after: Constants.longDelay)
+                    orderTracker.append(-1)
+                }
+                group.leave()
+            } catch {
+                Issue.record("Lock execution failed: \(error)")
+                group.leave()
+            }
+        }
+
+        group.enter()
+        queue.async {
+            do {
+                try lockManager.withLock(for: identityKey) {
+                    orderTracker.append(2)
+                    counter.increment(after: Constants.longDelay)
+                    orderTracker.append(-2)
+                }
+                group.leave()
+            } catch {
+                Issue.record("Lock execution failed: \(error)")
+                group.leave()
+            }
+        }
+
+        let timeoutResult = group.wait(timeout: .now() + Constants.shortTimeout)
+        #expect(timeoutResult == .success, "Operations timed out")
+
+        #expect(counter.value == 2, "With proper locking, counter should be 2 but got \(counter.value)")
+
+        #expect(orderTracker.checkNoInterleaving(), "Operations interleaved - lock is not working properly. Order: \(orderTracker.order)")
+
+        let validPatterns = [
+            [1, -1, 2, -2],  // Operation 1 completes, then operation 2
+            [2, -2, 1, -1]   // Operation 2 completes, then operation 1
+        ]
+
+        let patternMatches = validPatterns.contains { orderTracker.order == $0 }
+        #expect(patternMatches, "Expected a valid operation sequence. Got: \(orderTracker.order)")
+    }
+
+    @Test("FHIRResourceLockManager - Concurrent Lock Access")
+    func testConcurrentLockAccess() throws {
+        let identityKey = Constants.standardIdentityKey
+
+        let orderTracker = UnsafeOrderTracker()
+        let counter = UnsafeCounter()
+        let iterations = Constants.iterations
+
+        let group = DispatchGroup()
+        let queue = DispatchQueue(label: "com.test.concurrent", attributes: .concurrent)
+
+        for iterationStep in 0..<iterations * 2 {
+            group.enter()
+            queue.async {
+                do {
+                    let opType = (iterationStep % 2) + 1
+                    try lockManager.withLock(for: identityKey) {
+                        orderTracker.append(opType)
+                        counter.increment(after: Constants.shortDelay)
+                        orderTracker.append(-opType)
+                    }
+                    group.leave()
+                } catch {
+                    Issue.record("Lock execution failed: \(error)")
+                    group.leave()
+                }
+            }
+        }
+
+        let timeoutResult = group.wait(timeout: .now() + Constants.longTimeout)
+        #expect(timeoutResult == .success, "Operations timed out")
+
+        #expect(counter.value == iterations * 2, "With proper locking, counter should be \(iterations * 2) but got \(counter.value)")
+
+        #expect(orderTracker.checkNoInterleaving(), "Operations interleaved - lock is not working properly")
+    }
+
+    // swiftlint:disable function_body_length
+    @Test("FHIRResourceLockManager - Multiple Distinct Locks")
+    func testMultipleDistinctLocks() throws {
+        let identityKeys = Constants.multipleIdentityKeys
+
+        let trackers: [String: UnsafeKeyAwareOrderTracker] = {
+            var result = [String: UnsafeKeyAwareOrderTracker]()
+            for key in identityKeys {
+                result[key] = UnsafeKeyAwareOrderTracker()
+            }
+            return result
+        }()
+
+        let counters: [String: UnsafeCounter] = {
+            var result = [String: UnsafeCounter]()
+            for key in identityKeys {
+                result[key] = UnsafeCounter()
+            }
+            return result
+        }()
+
+        let totalKey = "global-counter"
+        let totalCounter = UnsafeCounter()
+
+        let iterations = Constants.iterations
+        let group = DispatchGroup()
+        let queue = DispatchQueue(label: "com.test.concurrent", attributes: .concurrent)
+
+        for identityKey in identityKeys {
+            guard let tracker = trackers[identityKey],
+                  let counter = counters[identityKey] else {
+                Issue.record("Missing tracker or counter for key: \(identityKey)")
+                return
+            }
+
+            for iterationStep in 0..<iterations * 2 {
+                group.enter()
+                queue.async {
+                    do {
+                        let opType = (iterationStep % 2) + 1
+                        try lockManager.withLock(for: identityKey) {
+                            tracker.append(key: identityKey, opType: opType)
+                            counter.increment(after: Constants.shortDelay)
+                            tracker.append(key: identityKey, opType: -opType)
+                        }
+
+                        try lockManager.withLock(for: totalKey) {
+                            totalCounter.increment()
+                        }
+
+                        group.leave()
+                    } catch {
+                        Issue.record("Lock execution failed: \(error)")
+                        group.leave()
+                    }
+                }
+            }
+        }
+
+        let timeoutResult = group.wait(timeout: .now() + Constants.longTimeout)
+        #expect(timeoutResult == .success, "Operations timed out")
+
+        for key in identityKeys {
+            guard let counter = counters[key] else {
+                Issue.record("Missing counter for key: \(key)")
+                continue
+            }
+
+            let expectedKeyOperations = iterations * 2
+            #expect(counter.value == expectedKeyOperations, "Expected \(expectedKeyOperations) operations for key \(key) but got \(counter.value)")
+        }
+
+        let expectedTotal = identityKeys.count * iterations * 2
+        #expect(totalCounter.value == expectedTotal, "Expected \(expectedTotal) total operations but got \(totalCounter.value)")
+
+        for key in identityKeys {
+            guard let tracker = trackers[key] else {
+                Issue.record("Missing tracker for key: \(key)")
+                continue
+            }
+
+            #expect(tracker.checkNoInterleavingPerKey(), "Operations with key \(key) interleaved - lock is not working properly")
+        }
+    }
+}
+
+extension FHIRResourceLockManagerTests {
+    class UnsafeCounter: @unchecked Sendable {
+        var value = 0
+
+        func increment(after delay: TimeInterval? = nil) {
+            let current = value
+            if let delay {
+                Thread.sleep(forTimeInterval: delay)
+            }
+            value = current + 1
+        }
+    }
+
+    class UnsafeOrderTracker: @unchecked Sendable {
+        var order = [Int]()
+
+        func append(_ value: Int) {
+            order.append(value)
+        }
+
+        func checkNoInterleaving() -> Bool {
+            var activeOp: Int?
+
+            for entry in order {
+                if entry > 0 {
+                    // If another operation is already active, we have interleaving
+                    if activeOp != nil {
+                        return false
+                    }
+                    activeOp = entry
+                } else {
+                    // Should match the active operation
+                    if activeOp != abs(entry) {
+                        return false
+                    }
+                    activeOp = nil
+                }
+            }
+
+            return true
+        }
+    }
+
+    class UnsafeKeyAwareOrderTracker: @unchecked Sendable {
+        var operations = [(key: String, opType: Int)]()
+
+        private var activeOps = [String: Int]()
+
+        func append(key: String, opType: Int) {
+            operations.append((key: key, opType: opType))
+
+            if opType > 0 {
+                activeOps[key] = opType
+            } else {
+                activeOps[key] = nil
+            }
+        }
+
+        func checkNoInterleavingPerKey() -> Bool {
+            var activeOperationsByKey = [String: Int]()
+
+            for operation in operations {
+                let key = operation.key
+                let opType = operation.opType
+
+                if opType > 0 {
+                    // If we already have an active operation for this key, that's interleaving
+                    if activeOperationsByKey[key] != nil {
+                        return false
+                    }
+                    activeOperationsByKey[key] = opType
+                } else {
+                    // Should match an active operation for this key
+                    if activeOperationsByKey[key] != abs(opType) {
+                        return false
+                    }
+                    activeOperationsByKey[key] = nil
+                }
+            }
+
+            return true
+        }
+    }
+}


### PR DESCRIPTION
# Improve `copy` with per-resource locking

## :recycle: Current situation & Problem
LLMonFHIR - [#79](https://github.com/StanfordBDHG/LLMonFHIR/issues/79)


## :gear: Release Notes
- Implemented thread-safe deep copying for FHIR resources using per-resource locking.
- ~~Using `PropertyListEncoder/Decoder` instead of `JSONEncoder/Decoder`. `PropertyListEncoder/Decoder` should be faster than `JSONEncoder/Decoder` as they use binary data instead of text, skipping the need for text formatting and character escaping.~~

## :books: Documentation
Added in code.


## :white_check_mark: Testing
Should: 
- [x] Measure how much overhead our thread safety changes add to copy operations compared to the original implementation.
- [x] Measure if PropertyList encoding/decoding is actually faster than the current JSON approach for our FHIR resources. (Using `JSONEncoder/Decoder` is a better choice. Check the comments)
- [x] Run many copy operations simultaneously from different threads to check the thread safety


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
