### PR TITLE
various small improvements

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -215,7 +215,7 @@ only_rules:
   # Operators should be surrounded by a single whitespace when they are being used.
   - operator_usage_whitespace
   # Operators should be surrounded by a single whitespace when defining them.
-  - operator_whitespace
+  - function_name_whitespace
   # Matching an enum case against an optional enum without ‘?’ is supported on Swift 5.1 and above.
   - optional_enum_case_matching
   # A doc comment should be attached to a declaration.
@@ -257,7 +257,7 @@ only_rules:
   # Objective-C attribute (@objc) is redundant in declaration.
   - redundant_objc_attribute
   # Initializing an optional variable with nil is redundant.
-  - redundant_optional_initialization
+  - implicit_optional_initialization
   # Property setter access level shouldn't be explicit if it's the same as the variable access level.
   - redundant_set_access_control
   # String enum values can be omitted when they are equal to the enumcase name.

--- a/Sources/SpeziFHIR/Extensions/FHIR+Identifiable.swift
+++ b/Sources/SpeziFHIR/Extensions/FHIR+Identifiable.swift
@@ -14,4 +14,3 @@ extension Resource: @retroactive Identifiable {
 }
 
 
-extension FHIRPrimitive: @retroactive Identifiable where PrimitiveType: Identifiable { }

--- a/Sources/SpeziFHIR/Extensions/FHIR+Identifiable.swift
+++ b/Sources/SpeziFHIR/Extensions/FHIR+Identifiable.swift
@@ -6,11 +6,15 @@
 // SPDX-License-Identifier: MIT
 //
 
+import ModelsDSTU2
 import ModelsR4
 
 
-extension Resource: @retroactive Identifiable {
-    public typealias ID = FHIRPrimitive<FHIRString>?
+extension ModelsDSTU2.Resource: @retroactive Identifiable {
+    public typealias ID = ModelsDSTU2.FHIRPrimitive<ModelsDSTU2.FHIRString>?
 }
 
 
+extension ModelsR4.Resource: @retroactive Identifiable {
+    public typealias ID = ModelsR4.FHIRPrimitive<ModelsR4.FHIRString>?
+}

--- a/Sources/SpeziFHIR/FHIRAttachment/FHIRAttachment+DSTU2.swift
+++ b/Sources/SpeziFHIR/FHIRAttachment/FHIRAttachment+DSTU2.swift
@@ -13,9 +13,9 @@ import UniformTypeIdentifiers
 extension ModelsDSTU2.Attachment: FHIRAttachment {
     var debugDescription: String {
         """
-        Could not transform attachement type: \(title?.primitiveDescription ?? "No title") to a string representation.
+        Could not transform attachment type: \(title?.primitiveDescription ?? "No title") to a string representation.
         
-        Attachement: \(id?.primitiveDescription ?? "No ID")
+        Attachment: \(id?.primitiveDescription ?? "No ID")
             Creation Date: \(creation?.primitiveDescription ?? "No Creation")
             MIME Type: \(mimeType?.preferredMIMEType ?? "No Content Type")
         """

--- a/Sources/SpeziFHIR/FHIRAttachment/FHIRAttachment+R4.swift
+++ b/Sources/SpeziFHIR/FHIRAttachment/FHIRAttachment+R4.swift
@@ -13,9 +13,9 @@ import UniformTypeIdentifiers
 extension ModelsR4.Attachment: FHIRAttachment {
     var debugDescription: String {
         """
-        Could not transform attachement type: \(title?.primitiveDescription ?? "No title") to a string representation.
+        Could not transform attachment type: \(title?.primitiveDescription ?? "No title") to a string representation.
         
-        Attachement: \(id?.primitiveDescription ?? "No ID")
+        Attachment: \(id?.primitiveDescription ?? "No ID")
             Creation Date: \(creation?.primitiveDescription ?? "No Creation")
             MIME Type: \(mimeType?.preferredMIMEType ?? "No Content Type")
         """

--- a/Sources/SpeziFHIR/FHIRResource/FHIRResource+Category.swift
+++ b/Sources/SpeziFHIR/FHIRResource/FHIRResource+Category.swift
@@ -6,8 +6,8 @@
 // SPDX-License-Identifier: MIT
 //
 
-import enum ModelsR4.ResourceProxy
 import enum ModelsDSTU2.ResourceProxy
+import enum ModelsR4.ResourceProxy
 
 
 // swiftlint:disable file_length

--- a/Sources/SpeziFHIR/FHIRResource/FHIRResource+StringifyAttachment.swift
+++ b/Sources/SpeziFHIR/FHIRResource/FHIRResource+StringifyAttachment.swift
@@ -11,30 +11,30 @@ import ModelsR4
 
 
 extension FHIRResource {
-    /// Best effort function to transform the base64 data representatino of any ``FHIRAttachement`` to a string-based respresentation of the data type.
+    /// Best effort function to transform the base64 data representatino of any ``FHIRAttachment`` to a string-based respresentation of the data type.
     ///
     /// This funcationality is especially useful if the data content is inspected for debug purposes or passing it ot a LLM component.
-    public func stringifyAttachements() throws {
-        try stringifyAttachements(using: FHIRAttachmentService())
+    public func stringifyAttachments() throws {
+        try stringifyAttachments(using: FHIRAttachmentService())
     }
 
-    func stringifyAttachements(using service: FHIRAttachmentService) throws {
+    func stringifyAttachments(using service: FHIRAttachmentService) throws {
         switch versionedResource {
         case let .r4(r4Resource):
             guard let documentReference = r4Resource as? ModelsR4.DocumentReference else {
                 return
             }
             
-            for attachement in documentReference.content.compactMap(\.attachment) {
-                try service.stringify(attachment: attachement)
+            for attachment in documentReference.content.compactMap(\.attachment) {
+                try service.stringify(attachment: attachment)
             }
         case let .dstu2(dstu2Resource):
             guard let documentReference = dstu2Resource as? ModelsDSTU2.DocumentReference else {
                 return
             }
             
-            for attachement in documentReference.content.compactMap(\.attachment) {
-                try service.stringify(attachment: attachement)
+            for attachment in documentReference.content.compactMap(\.attachment) {
+                try service.stringify(attachment: attachment)
             }
         }
     }

--- a/Sources/SpeziFHIR/FHIRResource/FHIRResource.swift
+++ b/Sources/SpeziFHIR/FHIRResource/FHIRResource.swift
@@ -23,6 +23,13 @@ public struct FHIRResource: Identifiable, Hashable {
         case dstu2(ModelsDSTU2.Resource)
     }
     
+    public struct ID: Hashable, Codable, Sendable {
+        fileprivate let fhirResourceId: String
+        fileprivate let healthKitUUID: String?
+    }
+    
+    public static let fhirExtensionUrlHKSampleId = URL(string: "https://bdh.stanford.edu/fhir/defs/HealthKitSampleID")!
+    
     
     /// The version-specific FHIR resource.
     public let versionedResource: VersionedFHIRResource
@@ -30,23 +37,46 @@ public struct FHIRResource: Identifiable, Hashable {
     public let displayName: String
     
     
-    /// Unique identifier for the FHIR resource.
-    public var id: String {
+    public var id: ID {
         switch versionedResource {
         case let .r4(resource):
-            guard let id = resource.id?.value?.string else {
+            guard let fhirId else {
                 preconditionFailure(
                     "A stable identifier must be present when wrapping content in a FHIRResource. The identifier might have been changed."
                 )
             }
-            return id
+            return ID(fhirResourceId: fhirId, healthKitUUID: healthKitSampleId)
         case let .dstu2(resource):
-            guard let id = resource.id?.value?.string else {
+            guard let fhirId else {
                 preconditionFailure(
                     "A stable identifier must be present when wrapping content in a FHIRResource. The identifier might have been changed."
                 )
             }
-            return id
+            return ID(fhirResourceId: fhirId, healthKitUUID: healthKitSampleId)
+        }
+    }
+    
+    /// The `id` of the underlying FHIR `Resource`.
+    public var fhirId: String? {
+        switch versionedResource {
+        case let .r4(resource):
+            resource.id?.value?.string
+        case let .dstu2(resource):
+            resource.id?.value?.string
+        }
+    }
+    
+    /// The `uuid` of the `HKSample` from which this FHIRResource was created, if applicable.
+    var healthKitSampleId: String? {
+        switch versionedResource {
+        case let .r4(resource):
+            (resource as? ModelsR4.DomainResource)?
+                .extensions(for: Self.fhirExtensionUrlHKSampleId.absoluteString)
+                .first?.value?.idString
+        case let .dstu2(resource):
+            (resource as? ModelsDSTU2.DomainResource)?
+                .extensions(for: Self.fhirExtensionUrlHKSampleId.absoluteString)
+                .first?.value?.idString
         }
     }
     
@@ -208,6 +238,29 @@ public struct FHIRResource: Identifiable, Hashable {
             return (try? String(decoding: encoder.encode(resource), as: UTF8.self)) ?? "{}"
         case let .dstu2(resource):
             return (try? String(decoding: encoder.encode(resource), as: UTF8.self)) ?? "{}"
+        }
+    }
+}
+
+
+extension ModelsDSTU2.Extension.ValueX {
+    fileprivate var idString: String? {
+        switch self {
+        case .id(let value):
+            value.value?.string
+        default:
+            nil
+        }
+    }
+}
+
+extension ModelsR4.Extension.ValueX {
+    fileprivate var idString: String? {
+        switch self {
+        case .id(let value):
+            value.value?.string
+        default:
+            nil
         }
     }
 }

--- a/Sources/SpeziFHIR/FHIRResource/FHIRResource.swift
+++ b/Sources/SpeziFHIR/FHIRResource/FHIRResource.swift
@@ -29,6 +29,7 @@ public struct FHIRResource: Identifiable, Hashable {
     }
     
     public static let fhirExtensionUrlHKSampleId = URL(string: "https://bdh.stanford.edu/fhir/defs/HealthKitSampleID")!
+    // swiftlint:disable:previous force_unwrapping
     
     
     /// The version-specific FHIR resource.

--- a/Sources/SpeziFHIR/FHIRResource/FHIRResource.swift
+++ b/Sources/SpeziFHIR/FHIRResource/FHIRResource.swift
@@ -24,8 +24,9 @@ public struct FHIRResource: Identifiable, Hashable {
     }
     
     public struct ID: Hashable, Codable, Sendable {
-        fileprivate let fhirResourceId: String
-        fileprivate let healthKitUUID: String?
+        @_spi(Testing) public let fhirResourceId: String
+        
+        @_spi(Testing) public let healthKitUUID: String?
     }
     
     public static let fhirExtensionUrlHKSampleId = URL(string: "https://bdh.stanford.edu/fhir/defs/HealthKitSampleID")!
@@ -39,22 +40,12 @@ public struct FHIRResource: Identifiable, Hashable {
     
     
     public var id: ID {
-        switch versionedResource {
-        case let .r4(resource):
-            guard let fhirId else {
-                preconditionFailure(
-                    "A stable identifier must be present when wrapping content in a FHIRResource. The identifier might have been changed."
-                )
-            }
-            return ID(fhirResourceId: fhirId, healthKitUUID: healthKitSampleId)
-        case let .dstu2(resource):
-            guard let fhirId else {
-                preconditionFailure(
-                    "A stable identifier must be present when wrapping content in a FHIRResource. The identifier might have been changed."
-                )
-            }
-            return ID(fhirResourceId: fhirId, healthKitUUID: healthKitSampleId)
+        guard let fhirId else {
+            preconditionFailure(
+                "A stable identifier must be present when wrapping content in a FHIRResource. The identifier might have been changed."
+            )
         }
+        return ID(fhirResourceId: fhirId, healthKitUUID: healthKitSampleId)
     }
     
     /// The `id` of the underlying FHIR `Resource`.

--- a/Sources/SpeziFHIR/FHIRResource/FHIRResource.swift
+++ b/Sources/SpeziFHIR/FHIRResource/FHIRResource.swift
@@ -25,7 +25,6 @@ public struct FHIRResource: Identifiable, Hashable {
     
     public struct ID: Hashable, Codable, Sendable {
         @_spi(Testing) public let fhirResourceId: String
-        
         @_spi(Testing) public let healthKitUUID: String?
     }
     

--- a/Sources/SpeziFHIR/FHIRStore.swift
+++ b/Sources/SpeziFHIR/FHIRStore.swift
@@ -99,9 +99,7 @@ public final class FHIRStore: Module, EnvironmentAccessible, DefaultInitializabl
     @MainActor
     public func insert(resource: FHIRResource) {
         _$observationRegistrar.willSet(self, keyPath: resource.category.storeKeyPath)
-
         _resources.append(resource)
-
         _$observationRegistrar.didSet(self, keyPath: resource.category.storeKeyPath)
     }
 
@@ -111,13 +109,10 @@ public final class FHIRStore: Module, EnvironmentAccessible, DefaultInitializabl
     @MainActor
     public func insert<T: Collection>(resources: T) where T.Element == FHIRResource {
         let resourceCategories = Set(resources.map(\.category))
-
         for category in resourceCategories {
             _$observationRegistrar.willSet(self, keyPath: category.storeKeyPath)
         }
-
         self._resources.append(contentsOf: resources)
-
         for category in resourceCategories {
             _$observationRegistrar.didSet(self, keyPath: category.storeKeyPath)
         }
@@ -152,17 +147,28 @@ public final class FHIRStore: Module, EnvironmentAccessible, DefaultInitializabl
 
     /// Removes a FHIR resource from the ``FHIRStore``.
     ///
-    /// - Parameter resource: The `FHIRResource` identifier to be inserted.
+    /// - Parameter fhirId: The FHIR `id` of the resource that should be removed.
     @MainActor
-    public func remove(resource resourceId: FHIRResource.ID) {
-        guard let resource = _resources.first(where: { $0.id == resourceId }) else {
+    public func removeResource(withId fhirId: String) {
+        guard let resource = _resources.first(where: { $0.fhirId == fhirId }) else {
             return
         }
-
         _$observationRegistrar.willSet(self, keyPath: resource.category.storeKeyPath)
-
-        _resources.removeAll { $0.id == resourceId }
-
+        _resources.removeAll { $0.fhirId == fhirId }
+        _$observationRegistrar.didSet(self, keyPath: resource.category.storeKeyPath)
+    }
+    
+    /// Removes a FHIR resource from the ``FHIRStore``.
+    ///
+    /// - Parameter healthKitId: The HealthKit `uuid` of the resource that should be removed.
+    @_spi(Internal)
+    @MainActor
+    public func removeResource(withHealthKitUUID healthKitId: String) {
+        guard let resource = _resources.first(where: { $0.healthKitSampleId == healthKitId }) else {
+            return
+        }
+        _$observationRegistrar.willSet(self, keyPath: resource.category.storeKeyPath)
+        _resources.removeAll { $0.healthKitSampleId == healthKitId }
         _$observationRegistrar.didSet(self, keyPath: resource.category.storeKeyPath)
     }
 
@@ -172,9 +178,7 @@ public final class FHIRStore: Module, EnvironmentAccessible, DefaultInitializabl
         for category in FHIRResource.FHIRResourceCategory.allCases {
             _$observationRegistrar.willSet(self, keyPath: category.storeKeyPath)
         }
-
         _resources = []
-
         for category in FHIRResource.FHIRResourceCategory.allCases {
             _$observationRegistrar.didSet(self, keyPath: category.storeKeyPath)
         }

--- a/Sources/SpeziFHIR/FHIRStore.swift
+++ b/Sources/SpeziFHIR/FHIRStore.swift
@@ -6,9 +6,9 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Observation
-import class ModelsR4.Bundle
 import enum ModelsDSTU2.ResourceProxy
+import class ModelsR4.Bundle
+import Observation
 import Spezi
 import SpeziHealthKit
 

--- a/Sources/SpeziFHIRHealthKit/FHIRResource+HealthKit.swift
+++ b/Sources/SpeziFHIRHealthKit/FHIRResource+HealthKit.swift
@@ -18,13 +18,13 @@ extension FHIRResource {
     /// Creates a new ``FHIRResource`` instance using an `HKSample`.
     /// - Parameters:
     ///   - sample: The sample that should be transformed in a ``FHIRResource``.
-    ///   - healthKit: Optional `HealthKit` module used to query additional context such as symptoms and voltage measurements for electrocardiograms and attachements for clinical records.
-    ///   - loadHealthKitAttachements: Indicates if the `HKAttachmentStore` should be queried for any document references found in clinical records.
+    ///   - healthKit: Optional `HealthKit` module used to query additional context such as symptoms and voltage measurements for electrocardiograms and attachments for clinical records.
+    ///   - loadHealthKitAttachments: Indicates if the `HKAttachmentStore` should be queried for any document references found in clinical records.
     /// - Returns: Created ``FHIRResource`` instance.
     public static func initialize(
         basedOn sample: HKSample,
         using healthKit: HealthKit? = nil,
-        loadHealthKitAttachements: Bool = false
+        loadHealthKitAttachments: Bool = false
     ) async throws -> FHIRResource {
         switch sample {
         case let clinicalResource as HKClinicalRecord where clinicalResource.fhirResource?.fhirVersion == .primaryDSTU2():
@@ -40,8 +40,8 @@ extension FHIRResource {
                 versionedResource: .dstu2(fhirModelResource),
                 displayName: clinicalResource.displayName
             )
-            if loadHealthKitAttachements, let healthKit = healthKit {
-                try await resource.loadAttachements(for: sample, using: healthKit)
+            if loadHealthKitAttachments, let healthKit = healthKit {
+                try await resource.loadAttachments(for: sample, using: healthKit)
             }
             return resource
         case let clinicalResource as HKClinicalRecord:
@@ -51,8 +51,8 @@ extension FHIRResource {
                 versionedResource: .r4(fhirModelResource),
                 displayName: clinicalResource.displayName
             )
-            if loadHealthKitAttachements, let healthKit = healthKit {
-                try await resource.loadAttachements(for: sample, using: healthKit)
+            if loadHealthKitAttachments, let healthKit = healthKit {
+                try await resource.loadAttachments(for: sample, using: healthKit)
             }
             return resource
         case let electrocardiogram as HKElectrocardiogram:

--- a/Sources/SpeziFHIRHealthKit/FHIRResource+HealthKit.swift
+++ b/Sources/SpeziFHIRHealthKit/FHIRResource+HealthKit.swift
@@ -27,34 +27,90 @@ extension FHIRResource {
         loadHealthKitAttachments: Bool = false
     ) async throws -> FHIRResource {
         switch sample {
-        case let clinicalResource as HKClinicalRecord where clinicalResource.fhirResource?.fhirVersion == .primaryDSTU2():
-            guard let fhirResource = clinicalResource.fhirResource else {
+        case let record as HKClinicalRecord:
+            guard let fhirResource = record.fhirResource else {
                 throw HealthKitOnFHIRError.invalidFHIRResource
             }
-            
             let decoder = JSONDecoder()
-            let resourceProxy = try decoder.decode(ModelsDSTU2.ResourceProxy.self, from: fhirResource.data)
-            let fhirModelResource = resourceProxy.get()
-            
-            var resource = FHIRResource(
-                versionedResource: .dstu2(fhirModelResource),
-                displayName: clinicalResource.displayName
-            )
-            if loadHealthKitAttachments, let healthKit = healthKit {
-                try await resource.loadAttachments(for: sample, using: healthKit)
+            switch fhirResource.fhirVersion.fhirRelease {
+            case .dstu2:
+                let resourceProxy = try decoder.decode(ModelsDSTU2.ResourceProxy.self, from: fhirResource.data)
+                if let domainResource = resourceProxy.get(if: ModelsDSTU2.DomainResource.self) {
+                    if domainResource.extension == nil {
+                        domainResource.extension = []
+                    }
+                    domainResource.extension!.append(
+                        ModelsDSTU2.Extension(
+                            url: Self.fhirExtensionUrlHKSampleId.asFHIRURIPrimitive(),
+                            value: .id(record.uuid.uuidString.asFHIRStringPrimitive())
+                        )
+                    )
+                }
+                var resource = FHIRResource(
+                    versionedResource: .dstu2(resourceProxy.get()),
+                    displayName: record.displayName
+                )
+                if loadHealthKitAttachments, let healthKit {
+                    try await resource.loadAttachments(for: record, using: healthKit)
+                }
+                return resource
+            case .r4:
+                let resourceProxy = try decoder.decode(ModelsR4.ResourceProxy.self, from: fhirResource.data)
+                if let domainResource = resourceProxy.get(if: ModelsR4.DomainResource.self) {
+                    if domainResource.extension == nil {
+                        domainResource.extension = []
+                    }
+                    domainResource.extension!.append(
+                        ModelsR4.Extension(
+                            url: Self.fhirExtensionUrlHKSampleId.asFHIRURIPrimitive(),
+                            value: .id(record.uuid.uuidString.asFHIRStringPrimitive())
+                        )
+                    )
+                }
+                var resource = FHIRResource(
+                    versionedResource: .r4(resourceProxy.get()),
+                    displayName: record.displayName
+                )
+                if loadHealthKitAttachments, let healthKit {
+                    try await resource.loadAttachments(for: record, using: healthKit)
+                }
+                return resource
+            case .unknown:
+                fallthrough
+            default:
+                throw HealthKitOnFHIRError.invalidFHIRResource
             }
-            return resource
-        case let clinicalResource as HKClinicalRecord:
-            let fhirModelResource = try clinicalResource.resource().get()
-            
-            var resource = FHIRResource(
-                versionedResource: .r4(fhirModelResource),
-                displayName: clinicalResource.displayName
-            )
-            if loadHealthKitAttachments, let healthKit = healthKit {
-                try await resource.loadAttachments(for: sample, using: healthKit)
-            }
-            return resource
+//        case let clinicalResource as HKClinicalRecord where clinicalResource.fhirResource?.fhirVersion == .primaryDSTU2():
+//            guard let fhirResource = clinicalResource.fhirResource else {
+//                throw HealthKitOnFHIRError.invalidFHIRResource
+//            }
+//            
+//            let decoder = JSONDecoder()
+//            let resourceProxy = try decoder.decode(ModelsDSTU2.ResourceProxy.self, from: fhirResource.data)
+//            let fhirModelResource = resourceProxy.get()
+//            if let domainResource = resourceProxy.get(if: ModelsDSTU2.DomainResource.self) {
+//                if let
+//            }
+//            
+//            var resource = FHIRResource(
+//                versionedResource: .dstu2(fhirModelResource),
+//                displayName: clinicalResource.displayName
+//            )
+//            if loadHealthKitAttachments, let healthKit = healthKit {
+//                try await resource.loadAttachments(for: sample, using: healthKit)
+//            }
+//            return resource
+//        case let clinicalResource as HKClinicalRecord:
+//            let fhirModelResource = try clinicalResource.resource().get()
+//            
+//            var resource = FHIRResource(
+//                versionedResource: .r4(fhirModelResource),
+//                displayName: clinicalResource.displayName
+//            )
+//            if loadHealthKitAttachments, let healthKit = healthKit {
+//                try await resource.loadAttachments(for: sample, using: healthKit)
+//            }
+//            return resource
         case let electrocardiogram as HKElectrocardiogram:
             guard let healthKit = healthKit else {
                 fallthrough

--- a/Sources/SpeziFHIRHealthKit/FHIRResource+HealthKit.swift
+++ b/Sources/SpeziFHIRHealthKit/FHIRResource+HealthKit.swift
@@ -21,7 +21,7 @@ extension FHIRResource {
     ///   - healthKit: Optional `HealthKit` module used to query additional context such as symptoms and voltage measurements for electrocardiograms and attachments for clinical records.
     ///   - loadHealthKitAttachments: Indicates if the `HKAttachmentStore` should be queried for any document references found in clinical records.
     /// - Returns: Created ``FHIRResource`` instance.
-    public static func initialize(
+    public static func initialize( // swiftlint:disable:this function_body_length cyclomatic_complexity
         basedOn sample: HKSample,
         using healthKit: HealthKit? = nil,
         loadHealthKitAttachments: Bool = false
@@ -39,7 +39,7 @@ extension FHIRResource {
                     if domainResource.extension == nil {
                         domainResource.extension = []
                     }
-                    domainResource.extension!.append(
+                    domainResource.extension!.append( // swiftlint:disable:this force_unwrapping
                         ModelsDSTU2.Extension(
                             url: Self.fhirExtensionUrlHKSampleId.asFHIRURIPrimitive(),
                             value: .id(record.uuid.uuidString.asFHIRStringPrimitive())
@@ -60,7 +60,7 @@ extension FHIRResource {
                     if domainResource.extension == nil {
                         domainResource.extension = []
                     }
-                    domainResource.extension!.append(
+                    domainResource.extension!.append( // swiftlint:disable:this force_unwrapping
                         ModelsR4.Extension(
                             url: Self.fhirExtensionUrlHKSampleId.asFHIRURIPrimitive(),
                             value: .id(record.uuid.uuidString.asFHIRStringPrimitive())
@@ -76,7 +76,7 @@ extension FHIRResource {
                 }
                 return resource
             case .unknown:
-                fallthrough
+                fallthrough // swiftlint:disable:this no_fallthrough_only
             default:
                 throw HealthKitOnFHIRError.invalidFHIRResource
             }

--- a/Sources/SpeziFHIRHealthKit/FHIRResource+HealthKit.swift
+++ b/Sources/SpeziFHIRHealthKit/FHIRResource+HealthKit.swift
@@ -80,37 +80,6 @@ extension FHIRResource {
             default:
                 throw HealthKitOnFHIRError.invalidFHIRResource
             }
-//        case let clinicalResource as HKClinicalRecord where clinicalResource.fhirResource?.fhirVersion == .primaryDSTU2():
-//            guard let fhirResource = clinicalResource.fhirResource else {
-//                throw HealthKitOnFHIRError.invalidFHIRResource
-//            }
-//            
-//            let decoder = JSONDecoder()
-//            let resourceProxy = try decoder.decode(ModelsDSTU2.ResourceProxy.self, from: fhirResource.data)
-//            let fhirModelResource = resourceProxy.get()
-//            if let domainResource = resourceProxy.get(if: ModelsDSTU2.DomainResource.self) {
-//                if let
-//            }
-//            
-//            var resource = FHIRResource(
-//                versionedResource: .dstu2(fhirModelResource),
-//                displayName: clinicalResource.displayName
-//            )
-//            if loadHealthKitAttachments, let healthKit = healthKit {
-//                try await resource.loadAttachments(for: sample, using: healthKit)
-//            }
-//            return resource
-//        case let clinicalResource as HKClinicalRecord:
-//            let fhirModelResource = try clinicalResource.resource().get()
-//            
-//            var resource = FHIRResource(
-//                versionedResource: .r4(fhirModelResource),
-//                displayName: clinicalResource.displayName
-//            )
-//            if loadHealthKitAttachments, let healthKit = healthKit {
-//                try await resource.loadAttachments(for: sample, using: healthKit)
-//            }
-//            return resource
         case let electrocardiogram as HKElectrocardiogram:
             guard let healthKit = healthKit else {
                 fallthrough

--- a/Sources/SpeziFHIRHealthKit/FHIRResource+LoadAttachments.swift
+++ b/Sources/SpeziFHIRHealthKit/FHIRResource+LoadAttachments.swift
@@ -56,7 +56,7 @@ extension FHIRResource {
     ///   - healthKitSample: The HealthKit sample containing attachments.
     ///   - store: The health store to use. Defaults to a new `HKHealthStore` instance.
     ///   - attachmentsProvider: Optional custom provider for attachments. If nil, a default provider will be created.
-    mutating func loadAttachements(
+    mutating func loadAttachments(
         for healthKitSample: HKSample,
         using healthKit: HealthKit,
         attachmentsProvider: (any HealthKitAttachmentsProvider)? = nil
@@ -71,13 +71,13 @@ extension FHIRResource {
         // Otherwise we create a new content entry to inject this information in here.
         switch versionedResource {
         case let .r4(r4Resource):
-            try processAttachementsForR4(r4Resource: r4Resource, encodedAttachments: encodedAttachments)
+            try processAttachmentsForR4(r4Resource: r4Resource, encodedAttachments: encodedAttachments)
         case let .dstu2(dstu2Resource):
-            try processAttachementsForDSTU2(dstu2Resource: dstu2Resource, encodedAttachments: encodedAttachments)
+            try processAttachmentsForDSTU2(dstu2Resource: dstu2Resource, encodedAttachments: encodedAttachments)
         }
     }
 
-    func processAttachementsForR4(
+    func processAttachmentsForR4(
         r4Resource: ModelsR4.Resource,
         encodedAttachments: [(identifier: String, base64EncodedString: String)]
     ) throws {
@@ -120,7 +120,7 @@ extension FHIRResource {
         }
     }
 
-    func processAttachementsForDSTU2(
+    func processAttachmentsForDSTU2(
         dstu2Resource: ModelsDSTU2.Resource,
         encodedAttachments: [(identifier: String, base64EncodedString: String)]
     ) throws {

--- a/Sources/SpeziFHIRHealthKit/FHIRResource+LoadAttachments.swift
+++ b/Sources/SpeziFHIRHealthKit/FHIRResource+LoadAttachments.swift
@@ -70,18 +70,19 @@ extension FHIRResource {
         // We assume that the content type is a MIME type, we would need to more checks around the content.format to be fully correct.
         // Otherwise we create a new content entry to inject this information in here.
         switch versionedResource {
-        case let .r4(r4Resource):
-            try processAttachmentsForR4(r4Resource: r4Resource, encodedAttachments: encodedAttachments)
-        case let .dstu2(dstu2Resource):
-            try processAttachmentsForDSTU2(dstu2Resource: dstu2Resource, encodedAttachments: encodedAttachments)
+        case let .r4(resource):
+            try processAttachments(for: resource, encodedAttachments: encodedAttachments)
+        case let .dstu2(resource):
+            try processAttachments(for: resource, encodedAttachments: encodedAttachments)
         }
     }
 
-    func processAttachmentsForR4(
-        r4Resource: ModelsR4.Resource,
+    func processAttachments(
+        for resource: ModelsR4.Resource,
         encodedAttachments: [(identifier: String, base64EncodedString: String)]
     ) throws {
-        if let documentReference = r4Resource as? ModelsR4.DocumentReference {
+        switch resource {
+        case let documentReference as ModelsR4.DocumentReference:
             for attachment in encodedAttachments {
                 let data = FHIRPrimitive(ModelsR4.Base64Binary(attachment.base64EncodedString))
                 if let matchingContent = documentReference.content.first(where: {
@@ -96,7 +97,7 @@ extension FHIRResource {
                     )
                 }
             }
-        } else if let diagnosticReport = r4Resource as? ModelsR4.DiagnosticReport {
+        case let diagnosticReport as ModelsR4.DiagnosticReport:
             for attachment in encodedAttachments {
                 let data = FHIRPrimitive(ModelsR4.Base64Binary(attachment.base64EncodedString))
                 if let presentedForms = diagnosticReport.presentedForm {
@@ -115,16 +116,17 @@ extension FHIRResource {
                     ]
                 }
             }
-        } else {
-            print("Unexpected FHIR type in the document parsing path: \(r4Resource.description)")
+        default:
+            print("Unexpected FHIR type in the document parsing path: \(resource.description)")
         }
     }
 
-    func processAttachmentsForDSTU2(
-        dstu2Resource: ModelsDSTU2.Resource,
+    func processAttachments(
+        for resource: ModelsDSTU2.Resource,
         encodedAttachments: [(identifier: String, base64EncodedString: String)]
     ) throws {
-        if let documentReference = dstu2Resource as? ModelsDSTU2.DocumentReference {
+        switch resource {
+        case let documentReference as ModelsDSTU2.DocumentReference:
             for attachment in encodedAttachments {
                 let data = FHIRPrimitive(ModelsDSTU2.Base64Binary(attachment.base64EncodedString))
                 if let matchingContent = documentReference.content.first(where: {
@@ -139,7 +141,7 @@ extension FHIRResource {
                     )
                 }
             }
-        } else if let diagnosticReport = dstu2Resource as? ModelsDSTU2.DiagnosticReport {
+        case let diagnosticReport as ModelsDSTU2.DiagnosticReport:
             for attachment in encodedAttachments {
                 let data = FHIRPrimitive(ModelsDSTU2.Base64Binary(attachment.base64EncodedString))
                 if let presentedForms = diagnosticReport.presentedForm {
@@ -158,8 +160,8 @@ extension FHIRResource {
                     ]
                 }
             }
-        } else {
-            print("Unexpected FHIR type in the document parsing path: \(dstu2Resource.description)")
+        default:
+            print("Unexpected FHIR type in the document parsing path: \(resource.description)")
         }
     }
 }

--- a/Sources/SpeziFHIRHealthKit/FHIRStore+HealthKit.swift
+++ b/Sources/SpeziFHIRHealthKit/FHIRStore+HealthKit.swift
@@ -18,14 +18,14 @@ extension FHIRStore {
     /// Add a HealthKit sample to the FHIR store.
     /// - Parameters:
     ///   - sample: The sample that should be added.
-    ///   - loadHealthKitAttachements: Indicates if the `HKAttachmentStore` should be queried for any document references found in clinical records.
+    ///   - loadHealthKitAttachments: Indicates if the `HKAttachmentStore` should be queried for any document references found in clinical records.
     public func add(
         sample: HKSample,
-        loadHealthKitAttachements: Bool = false
+        loadHealthKitAttachments: Bool = false
     ) async throws {
         var resource = try await FHIRResource.initialize(basedOn: sample, using: healthKit)
-        if loadHealthKitAttachements {
-            try await resource.loadAttachements(for: sample, using: healthKit)
+        if loadHealthKitAttachments {
+            try await resource.loadAttachments(for: sample, using: healthKit)
         }
         await insert(resource: resource)
     }

--- a/Sources/SpeziFHIRHealthKit/FHIRStore+HealthKit.swift
+++ b/Sources/SpeziFHIRHealthKit/FHIRStore+HealthKit.swift
@@ -10,7 +10,7 @@ import HealthKit
 import HealthKitOnFHIR
 import ModelsDSTU2
 import ModelsR4
-import SpeziFHIR
+@_spi(Internal) import SpeziFHIR
 import SpeziHealthKit
 
 
@@ -20,7 +20,7 @@ extension FHIRStore {
     ///   - sample: The sample that should be added.
     ///   - loadHealthKitAttachments: Indicates if the `HKAttachmentStore` should be queried for any document references found in clinical records.
     public func add(
-        sample: HKSample,
+        _ sample: HKSample,
         loadHealthKitAttachments: Bool = false
     ) async throws {
         var resource = try await FHIRResource.initialize(basedOn: sample, using: healthKit)
@@ -32,7 +32,7 @@ extension FHIRStore {
     
     /// Remove a HealthKit sample delete object from the FHIR store.
     /// - Parameter sample: The sample delete object that should be removed.
-    public func remove(sample: HKDeletedObject) async {
-        await remove(resource: sample.uuid.uuidString)
+    public func remove(_ deletedObject: HKDeletedObject) async {
+        await removeResource(withHealthKitUUID: deletedObject.uuid.uuidString)
     }
 }

--- a/Tests/SpeziFHIRTests/FHIRResource/FHIRResourceStringifyTests.swift
+++ b/Tests/SpeziFHIRTests/FHIRResource/FHIRResourceStringifyTests.swift
@@ -26,7 +26,7 @@ struct FHIRResourceStringifyTests {
 
         let originalBase64 = attachment.base64String
 
-        try resource.stringifyAttachements(using: service)
+        try resource.stringifyAttachments(using: service)
 
         let transformedContent = attachment.base64String
 
@@ -43,7 +43,7 @@ struct FHIRResourceStringifyTests {
 
         let originalBase64 = pdfAttachment.base64String
 
-        try resource.stringifyAttachements(using: service)
+        try resource.stringifyAttachments(using: service)
 
         let transformedContent = pdfAttachment.base64String
 
@@ -59,7 +59,7 @@ struct FHIRResourceStringifyTests {
 
         let originalContents = docRef.content.compactMap { $0.attachment.base64String }
 
-        try resource.stringifyAttachements(using: service)
+        try resource.stringifyAttachments(using: service)
 
         let transformedContents = docRef.content.compactMap { $0.attachment.base64String }
 
@@ -73,7 +73,7 @@ struct FHIRResourceStringifyTests {
         let docRef = try ModelsR4Mocks.createDocumentReference(attachments: [])
         let resource = FHIRResource(versionedResource: .r4(docRef), displayName: "Empty Document")
 
-        try resource.stringifyAttachements(using: service)
+        try resource.stringifyAttachments(using: service)
 
         #expect(docRef.content.isEmpty, "Content array should remain empty")
     }
@@ -88,7 +88,7 @@ struct FHIRResourceStringifyTests {
 
         let originalBase64 = attachment.base64String
 
-        try resource.stringifyAttachements(using: service)
+        try resource.stringifyAttachments(using: service)
 
         let transformedContent = attachment.base64String
         #expect(transformedContent != nil)
@@ -105,7 +105,7 @@ struct FHIRResourceStringifyTests {
 
         let originalBase64 = pdfAttachment.base64String
 
-        try resource.stringifyAttachements(using: service)
+        try resource.stringifyAttachments(using: service)
 
         let transformedContent = pdfAttachment.base64String
         #expect(transformedContent != nil)

--- a/Tests/SpeziFHIRTests/FHIRResource/FHIRResourceTests.swift
+++ b/Tests/SpeziFHIRTests/FHIRResource/FHIRResourceTests.swift
@@ -9,7 +9,7 @@
 import Foundation
 import ModelsDSTU2
 import ModelsR4
-@testable import SpeziFHIR
+@testable @_spi(Testing) import SpeziFHIR
 import Testing
 
 
@@ -39,7 +39,7 @@ struct FHIRResourceTests {
             displayName: "Test Observation"
         )
         
-        #expect(resource.id == "observation-id")
+        #expect(resource.id.fhirResourceId == "observation-id")
         #expect(resource.displayName == "Test Observation")
         #expect(resource.resourceType == "Observation")
     }
@@ -53,7 +53,7 @@ struct FHIRResourceTests {
             displayName: "Test Observation"
         )
         
-        #expect(resource.id == "observation-id")
+        #expect(resource.id.fhirResourceId == "observation-id")
         #expect(resource.displayName == "Test Observation")
         #expect(resource.resourceType == "Observation")
     }

--- a/Tests/SpeziFHIRTests/FHIRStore/FHIRStoreObservationChangesTests.swift
+++ b/Tests/SpeziFHIRTests/FHIRStore/FHIRStoreObservationChangesTests.swift
@@ -8,7 +8,7 @@
 
 import ModelsR4
 import Observation
-@testable import SpeziFHIR
+@testable @_spi(Testing) import SpeziFHIR
 import Testing
 
 
@@ -96,7 +96,7 @@ struct FHIRStoreObservationChangesTests {
                 observationsExpectation()
             }
             
-            store.remove(resource: resource.id)
+            store.removeResource(withId: resource.id.fhirResourceId)
             
             #expect(store.procedures.isEmpty)
             #expect(store.observations.isEmpty)

--- a/Tests/SpeziFHIRTests/FHIRStore/FHIRStoreTests.swift
+++ b/Tests/SpeziFHIRTests/FHIRStore/FHIRStoreTests.swift
@@ -7,7 +7,7 @@
 //
 
 import ModelsR4
-@testable import SpeziFHIR
+@testable @_spi(Testing) import SpeziFHIR
 import Testing
 
 
@@ -75,7 +75,7 @@ struct FHIRStoreTests {
         store.insert(resource: resource)
         #expect(store.medications.count == 1)
         
-        store.remove(resource: resource.id)
+        store.removeResource(withId: resource.id.fhirResourceId)
         #expect(store.medications.isEmpty)
     }
 
@@ -124,8 +124,8 @@ struct FHIRStoreTests {
         
         #expect(store.conditions.count == 1)
         #expect(store.observations.count == 1)
-        #expect(store.conditions.first?.id.description == "condition-id")
-        #expect(store.observations.first?.id.description == "observation-id")
+        #expect(store.conditions.first?.fhirId == "condition-id")
+        #expect(store.observations.first?.fhirId == "observation-id")
     }
 
     @Test
@@ -164,7 +164,7 @@ struct FHIRStoreTests {
         await store.load(bundle: bundle)
         
         #expect(store.conditions.count == 1)
-        #expect(store.conditions.first?.id.description == "condition-id")
+        #expect(store.conditions.first?.id.fhirResourceId == "condition-id")
         #expect(store.otherResources.isEmpty)
     }
 
@@ -182,7 +182,7 @@ struct FHIRStoreTests {
         await store.load(bundle: bundle)
         
         #expect(store.conditions.count == 2)
-        #expect(store.conditions[0].id.description == "condition-id")
-        #expect(store.conditions[1].id.description == "condition-id")
+        #expect(store.conditions[0].id.fhirResourceId == "condition-id")
+        #expect(store.conditions[1].id.fhirResourceId == "condition-id")
     }
 }

--- a/Tests/SpeziFHIRTests/SpeziFHIRHealthKit/FHIRResourceAttachmentProcessingTests.swift
+++ b/Tests/SpeziFHIRTests/SpeziFHIRHealthKit/FHIRResourceAttachmentProcessingTests.swift
@@ -54,8 +54,8 @@ struct FHIRResourceAttachmentProcessingTests { // swiftlint:disable:this type_bo
                 displayName: "R4 Document Reference"
             )
 
-            try resource.processAttachmentsForR4(
-                r4Resource: docRef,
+            try resource.processAttachments(
+                for: docRef,
                 encodedAttachments: encodedAttachments
             )
 
@@ -100,8 +100,8 @@ struct FHIRResourceAttachmentProcessingTests { // swiftlint:disable:this type_bo
                 displayName: "DSTU2 Document Reference"
             )
 
-            try resource.processAttachmentsForDSTU2(
-                dstu2Resource: docRef,
+            try resource.processAttachments(
+                for: docRef,
                 encodedAttachments: encodedAttachments
             )
 
@@ -146,8 +146,8 @@ struct FHIRResourceAttachmentProcessingTests { // swiftlint:disable:this type_bo
                 displayName: "R4 Diagnostic Report"
             )
 
-            try resource.processAttachmentsForR4(
-                r4Resource: diagReport,
+            try resource.processAttachments(
+                for: diagReport,
                 encodedAttachments: encodedAttachments
             )
 
@@ -186,8 +186,8 @@ struct FHIRResourceAttachmentProcessingTests { // swiftlint:disable:this type_bo
                 displayName: "DSTU2 Diagnostic Report"
             )
 
-            try resource.processAttachmentsForDSTU2(
-                dstu2Resource: diagReport,
+            try resource.processAttachments(
+                for: diagReport,
                 encodedAttachments: encodedAttachments
             )
 
@@ -236,8 +236,8 @@ struct FHIRResourceAttachmentProcessingTests { // swiftlint:disable:this type_bo
                 displayName: "R4 Document Reference"
             )
 
-            try resource.processAttachmentsForR4(
-                r4Resource: docRef,
+            try resource.processAttachments(
+                for: docRef,
                 encodedAttachments: encodedAttachments
             )
 
@@ -268,8 +268,8 @@ struct FHIRResourceAttachmentProcessingTests { // swiftlint:disable:this type_bo
                 displayName: "DSTU2 Document Reference"
             )
 
-            try resource.processAttachmentsForDSTU2(
-                dstu2Resource: docRef,
+            try resource.processAttachments(
+                for: docRef,
                 encodedAttachments: encodedAttachments
             )
 
@@ -304,8 +304,8 @@ struct FHIRResourceAttachmentProcessingTests { // swiftlint:disable:this type_bo
                 displayName: "R4 Diagnostic Report"
             )
 
-            try resource.processAttachmentsForR4(
-                r4Resource: diagReport,
+            try resource.processAttachments(
+                for: diagReport,
                 encodedAttachments: encodedAttachments
             )
 
@@ -330,8 +330,8 @@ struct FHIRResourceAttachmentProcessingTests { // swiftlint:disable:this type_bo
                 displayName: "DSTU2 Diagnostic Report"
             )
 
-            try resource.processAttachmentsForDSTU2(
-                dstu2Resource: diagReport,
+            try resource.processAttachments(
+                for: diagReport,
                 encodedAttachments: encodedAttachments
             )
 
@@ -370,8 +370,8 @@ struct FHIRResourceAttachmentProcessingTests { // swiftlint:disable:this type_bo
                 displayName: "R4 Diagnostic Report"
             )
 
-            try resource.processAttachmentsForR4(
-                r4Resource: diagReport,
+            try resource.processAttachments(
+                for: diagReport,
                 encodedAttachments: encodedAttachments
             )
 
@@ -406,8 +406,8 @@ struct FHIRResourceAttachmentProcessingTests { // swiftlint:disable:this type_bo
                 displayName: "DSTU2 Diagnostic Report"
             )
 
-            try resource.processAttachmentsForDSTU2(
-                dstu2Resource: diagReport,
+            try resource.processAttachments(
+                for: diagReport,
                 encodedAttachments: encodedAttachments
             )
 

--- a/Tests/SpeziFHIRTests/SpeziFHIRHealthKit/FHIRResourceAttachmentProcessingTests.swift
+++ b/Tests/SpeziFHIRTests/SpeziFHIRHealthKit/FHIRResourceAttachmentProcessingTests.swift
@@ -54,7 +54,7 @@ struct FHIRResourceAttachmentProcessingTests { // swiftlint:disable:this type_bo
                 displayName: "R4 Document Reference"
             )
 
-            try resource.processAttachementsForR4(
+            try resource.processAttachmentsForR4(
                 r4Resource: docRef,
                 encodedAttachments: encodedAttachments
             )
@@ -100,7 +100,7 @@ struct FHIRResourceAttachmentProcessingTests { // swiftlint:disable:this type_bo
                 displayName: "DSTU2 Document Reference"
             )
 
-            try resource.processAttachementsForDSTU2(
+            try resource.processAttachmentsForDSTU2(
                 dstu2Resource: docRef,
                 encodedAttachments: encodedAttachments
             )
@@ -146,7 +146,7 @@ struct FHIRResourceAttachmentProcessingTests { // swiftlint:disable:this type_bo
                 displayName: "R4 Diagnostic Report"
             )
 
-            try resource.processAttachementsForR4(
+            try resource.processAttachmentsForR4(
                 r4Resource: diagReport,
                 encodedAttachments: encodedAttachments
             )
@@ -186,7 +186,7 @@ struct FHIRResourceAttachmentProcessingTests { // swiftlint:disable:this type_bo
                 displayName: "DSTU2 Diagnostic Report"
             )
 
-            try resource.processAttachementsForDSTU2(
+            try resource.processAttachmentsForDSTU2(
                 dstu2Resource: diagReport,
                 encodedAttachments: encodedAttachments
             )
@@ -236,7 +236,7 @@ struct FHIRResourceAttachmentProcessingTests { // swiftlint:disable:this type_bo
                 displayName: "R4 Document Reference"
             )
 
-            try resource.processAttachementsForR4(
+            try resource.processAttachmentsForR4(
                 r4Resource: docRef,
                 encodedAttachments: encodedAttachments
             )
@@ -268,7 +268,7 @@ struct FHIRResourceAttachmentProcessingTests { // swiftlint:disable:this type_bo
                 displayName: "DSTU2 Document Reference"
             )
 
-            try resource.processAttachementsForDSTU2(
+            try resource.processAttachmentsForDSTU2(
                 dstu2Resource: docRef,
                 encodedAttachments: encodedAttachments
             )
@@ -304,7 +304,7 @@ struct FHIRResourceAttachmentProcessingTests { // swiftlint:disable:this type_bo
                 displayName: "R4 Diagnostic Report"
             )
 
-            try resource.processAttachementsForR4(
+            try resource.processAttachmentsForR4(
                 r4Resource: diagReport,
                 encodedAttachments: encodedAttachments
             )
@@ -330,7 +330,7 @@ struct FHIRResourceAttachmentProcessingTests { // swiftlint:disable:this type_bo
                 displayName: "DSTU2 Diagnostic Report"
             )
 
-            try resource.processAttachementsForDSTU2(
+            try resource.processAttachmentsForDSTU2(
                 dstu2Resource: diagReport,
                 encodedAttachments: encodedAttachments
             )
@@ -370,7 +370,7 @@ struct FHIRResourceAttachmentProcessingTests { // swiftlint:disable:this type_bo
                 displayName: "R4 Diagnostic Report"
             )
 
-            try resource.processAttachementsForR4(
+            try resource.processAttachmentsForR4(
                 r4Resource: diagReport,
                 encodedAttachments: encodedAttachments
             )
@@ -406,7 +406,7 @@ struct FHIRResourceAttachmentProcessingTests { // swiftlint:disable:this type_bo
                 displayName: "DSTU2 Diagnostic Report"
             )
 
-            try resource.processAttachementsForDSTU2(
+            try resource.processAttachmentsForDSTU2(
                 dstu2Resource: diagReport,
                 encodedAttachments: encodedAttachments
             )

--- a/Tests/UITests/TestApp/ContentView.swift
+++ b/Tests/UITests/TestApp/ContentView.swift
@@ -63,7 +63,7 @@ struct ContentView: View {
                     }
                     ToolbarItem {
                         Button {
-                            fhirStore.remove(resource: additionalFHIRResourceId)
+                            fhirStore.removeResource(withId: additionalFHIRResourceId)
                         } label: {
                             Label("Remove", systemImage: "folder.badge.minus")
                                 .accessibilityLabel("Remove FHIR Resource")

--- a/Tests/UITests/TestApp/TestingStandard.swift
+++ b/Tests/UITests/TestApp/TestingStandard.swift
@@ -107,7 +107,7 @@ actor TestingStandard: Standard, HealthKitConstraint, EnvironmentAccessible {
             for newHealthKitSample in records {
                 sampleTaskGroup.addTask { [self] in
                     do {
-                        try await fhirStore.add(sample: newHealthKitSample, loadHealthKitAttachements: true)
+                        try await fhirStore.add(sample: newHealthKitSample, loadHealthKitAttachments: true)
                     } catch {
                         logger.error("Could not transform sample \(newHealthKitSample.id) to FHIR resource: \(error)")
                     }

--- a/Tests/UITests/TestApp/TestingStandard.swift
+++ b/Tests/UITests/TestApp/TestingStandard.swift
@@ -58,7 +58,7 @@ actor TestingStandard: Standard, HealthKitConstraint, EnvironmentAccessible {
         if useHealthKitResources {
             for sample in addedSamples {
                 do {
-                    try await fhirStore.add(sample: sample)
+                    try await fhirStore.add(sample)
                 } catch {
                     logger.error("Cloud not transform HealthKit sample with id: \(sample.id)")
                 }
@@ -70,7 +70,7 @@ actor TestingStandard: Standard, HealthKitConstraint, EnvironmentAccessible {
         for object in deletedObjects {
             samples.removeAll { $0.id == object.uuid }
             if useHealthKitResources {
-                await fhirStore.remove(sample: object)
+                await fhirStore.remove(object)
             }
         }
     }
@@ -107,7 +107,7 @@ actor TestingStandard: Standard, HealthKitConstraint, EnvironmentAccessible {
             for newHealthKitSample in records {
                 sampleTaskGroup.addTask { [self] in
                     do {
-                        try await fhirStore.add(sample: newHealthKitSample, loadHealthKitAttachments: true)
+                        try await fhirStore.add(newHealthKitSample, loadHealthKitAttachments: true)
                     } catch {
                         logger.error("Could not transform sample \(newHealthKitSample.id) to FHIR resource: \(error)")
                     }


### PR DESCRIPTION
# various small improvements


## :gear: Release Notes
- removed the `ModelsR4.FHIRPrimitive: Identifiable` extension
- added a `ModelsDSTU2.Resource: Identifiable` extension
- renamed "attachement" to "attachment"
- fixed `FHIRResource/id` being ambiguous for `FHIRResource`s created from `HKClinicalRecord`s (the issue being that HealthKit will happily return multiple, distinct(!) FHIR resources with identical `id`s, even though they represent completely different records
- renamed some functions to have better ergonomics when working with both R4 and DSTU2


## :books: Documentation
n/a


## :white_check_mark: Testing
n/a

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
