### PR TITLE
`FHIRStore`: handle duplicate entries

### DIFF
--- a/Sources/SpeziFHIR/FHIRResource/FHIRResource+Category.swift
+++ b/Sources/SpeziFHIR/FHIRResource/FHIRResource+Category.swift
@@ -41,7 +41,7 @@ extension FHIRResource {
         /// The ``FHIRStore`` property key path of the resource.
         ///
         /// - Note: Needs to be isolated on `MainActor` as the respective ``FHIRStore`` properties referred to by the `KeyPath` are isolated on the `MainActor`.
-        @MainActor var storeKeyPath: KeyPath<FHIRStore, [FHIRResource]> {
+        @MainActor var storeKeyPath: KeyPath<FHIRStore, Set<FHIRResource>> {
             switch self {
             case .allergyIntolerance: \.allergyIntolerances
             case .condition: \.conditions

--- a/Sources/SpeziFHIR/FHIRResource/FHIRResource+Search.swift
+++ b/Sources/SpeziFHIR/FHIRResource/FHIRResource+Search.swift
@@ -17,11 +17,11 @@ extension FHIRResource {
 }
 
 
-extension Array where Element == FHIRResource {
+extension Set where Element == FHIRResource {
     /// Filters the FHIR resources using the provided search text.
     /// - Parameter searchText: Filters the FHIR resources using the provided search text.
     /// - Returns: The filtered FHIR resources.
-    public func filterByDisplayName(with searchText: String) -> [FHIRResource] {
+    public func filterByDisplayName(with searchText: String) -> Self {
         if searchText.isEmpty {
             return self
         }

--- a/Sources/SpeziFHIR/FHIRStore.swift
+++ b/Sources/SpeziFHIR/FHIRStore.swift
@@ -18,14 +18,18 @@ import SpeziHealthKit
 /// The ``FHIRStore`` is automatically injected in the environment if you use the ``FHIR`` standard or can be used as a standalone module.
 @Observable
 public final class FHIRStore: Module, EnvironmentAccessible, DefaultInitializable, @unchecked Sendable { // unchecked bc of the HealthKit dependency
-    // The `_resources` array needs to be marked with `@ObservationIgnored` to prevent changes to this array
-    // from triggering updates to all computed properties.
-    // Instead, we explicitly control change notifications through `willSet`/`didSet` calls
-    // with specific keyPaths in the `insert`, `remove`, and other mutation methods. This ensures that
-    // only observers of the relevant category (e.g., observations, conditions) are notified when
-    // resources of that category are modified.
-    @ObservationIgnored @MainActor private var _resources: Set<FHIRResource> = []
     @ObservationIgnored @Dependency(HealthKit.self) package var healthKit
+    
+    /// The actual ``FHIRResource``s held by the ``FHIRStore``
+    ///
+    /// The `_resources` property needs to be marked with `@ObservationIgnored` to prevent changes to it
+    /// from triggering updates to all computed properties.
+    /// Instead, we explicitly control change notifications through `willSet`/`didSet` calls
+    /// with specific keyPaths in the `insert`, `remove`, and other mutation methods.
+    /// This ensures that only observers of the relevant category (e.g., observations, conditions) are notified when
+    /// resources of that category are modified.
+    /// See also the `mutatingResourceCategories` function
+    @ObservationIgnored @MainActor @usableFromInline var _resources: Set<FHIRResource> = [] // swiftlint:disable:this identifier_name
     
     
     /// `FHIRResource`s with category `allergyIntolerance`.
@@ -221,19 +225,37 @@ extension FHIRStore {
 // MARK: FHIRStore + Collection
 
 extension FHIRStore: @MainActor Collection {
-    @MainActor public var isEmpty: Bool {
+    public typealias Element = FHIRResource
+    
+    public struct Index: Comparable {
+        @usableFromInline let _index: Set<FHIRResource>.Index // swiftlint:disable:this identifier_name
+        
+        @inlinable
+        init(_ index: Set<FHIRResource>.Index) {
+            _index = index
+        }
+        
+        @inlinable
+        public static func < (lhs: Self, rhs: Self) -> Bool {
+            lhs._index < rhs._index
+        }
+    }
+    
+    
+    @MainActor @inlinable public var isEmpty: Bool {
         _resources.isEmpty
     }
     
-    @MainActor public var startIndex: Set<FHIRResource>.Index {
-        _resources.startIndex
+    @MainActor @inlinable public var startIndex: Index {
+        Index(_resources.startIndex)
     }
     
-    @MainActor public var endIndex: Set<FHIRResource>.Index {
-        _resources.endIndex
+    @MainActor @inlinable public var endIndex: Index {
+        Index(_resources.endIndex)
     }
     
     @MainActor
+    @inlinable
     public func _customContainsEquatableElement( // swiftlint:disable:this identifier_name
         _ element: FHIRResource
     ) -> Bool? { // swiftlint:disable:this discouraged_optional_boolean
@@ -241,21 +263,14 @@ extension FHIRStore: @MainActor Collection {
     }
     
     @MainActor
-    public func index(after idx: Set<FHIRResource>.Index) -> Set<FHIRResource>.Index {
-        _resources.index(after: idx)
+    @inlinable
+    public func index(after idx: Index) -> Index {
+        Index(_resources.index(after: idx._index))
     }
     
     @MainActor
-    public subscript(position: Set<FHIRResource>.Index) -> FHIRResource {
-        _resources[position]
-    }
-}
-
-
-extension Set {
-    fileprivate mutating func removeAll(where predicate: (Element) -> Bool) {
-        for element in self where predicate(element) {
-            remove(element)
-        }
+    @inlinable
+    public subscript(position: Index) -> FHIRResource {
+        _resources[position._index]
     }
 }

--- a/Sources/SpeziFHIR/FHIRStore.swift
+++ b/Sources/SpeziFHIR/FHIRStore.swift
@@ -91,36 +91,40 @@ public final class FHIRStore: Module, EnvironmentAccessible, DefaultInitializabl
     
     /// Create an empty ``FHIRStore``.
     public required init() {}
-    
-    
-    /// Inserts a FHIR resource into the ``FHIRStore``.
+}
+
+
+// MARK: FHIRStore Resource Insertion
+
+extension FHIRStore {
+    /// Inserts a FHIR resource into the ``FHIRStore``, unless it is already in the store.
     ///
-    /// - Parameter resource: The `FHIRResource` to be inserted.
+    /// - parameter resource: The `FHIRResource` to be inserted.
+    /// - returns: A `Bool` indicating whether the resource was inserted into the store. (I.e., `false` if the store already contained a resource with an equivalent id.)
     @MainActor
     @discardableResult
-    public func insert(resource: FHIRResource) -> Bool {
-        guard !_resources.contains(resource) else {
+    public func insert(_ resource: FHIRResource) -> Bool {
+        guard !self.contains(resource) else {
             return false
         }
-        _$observationRegistrar.willSet(self, keyPath: resource.category.storeKeyPath)
-        _resources.insert(resource)
-        _$observationRegistrar.didSet(self, keyPath: resource.category.storeKeyPath)
-        return true
+        return mutatingResourceCategories(CollectionOfOne(resource.category)) {
+            _resources.insert(resource).inserted
+        }
     }
     
-    /// Inserts a ``Collection`` of FHIR resources into the ``FHIRStore``.
+    /// Inserts multiple ``FHIRResource``s into the store.
+    ///
+    /// Any resources that already exist in the store will be skipped; only new resources will be inserted
     ///
     /// - Parameter resources: The `FHIRResource`s to be inserted.
     @MainActor
-    public func insert(resources: some Collection<FHIRResource>) {
-        let resources = resources.filter { !_resources.contains($0) }
-        let resourceCategories = Array(resources.mapIntoSet(\.category))
-        for category in resourceCategories {
-            _$observationRegistrar.willSet(self, keyPath: category.storeKeyPath)
+    public func insert(contentsOf resourcesToInsert: some Sequence<FHIRResource>) {
+        let resourcesToInsert = resourcesToInsert.filter { !self._resources.contains($0) }
+        guard !resourcesToInsert.isEmpty else {
+            return
         }
-        _resources.formUnion(resources)
-        for category in resourceCategories.reversed() {
-            _$observationRegistrar.didSet(self, keyPath: category.storeKeyPath)
+        mutatingResourceCategories(resourcesToInsert.lazy.map(\.category)) {
+            _resources.formUnion(resourcesToInsert)
         }
     }
     
@@ -128,69 +132,92 @@ public final class FHIRStore: Module, EnvironmentAccessible, DefaultInitializabl
     ///
     /// - Parameter bundle: The FHIR `Bundle` containing resources to be loaded.
     public func load(bundle: sending Bundle) async {
-        let resourceProxies = bundle.entry?.compactMap { $0.resource } ?? []
-        var resources: [FHIRResource] = []
-        
-        for resourceProxy in resourceProxies {
-            if Task.isCancelled {
-                return
-            }
-            
-            resources.append(
-                FHIRResource(
-                    resource: resourceProxy.get(),
-                    displayName: resourceProxy.displayName
-                )
-            )
-        }
-        
-        if Task.isCancelled {
+        guard let resourceProxies = bundle.entry?.compactMap(\.resource), !resourceProxies.isEmpty else {
             return
         }
-        
-        await insert(resources: resources)
+        await insert(contentsOf: resourceProxies.lazy.map {
+            FHIRResource(resource: $0.get(), displayName: $0.displayName)
+        })
     }
-    
+}
+
+
+// MARK: FHIRStore Resource Removal
+
+extension FHIRStore {
     /// Removes a FHIR resource from the ``FHIRStore``.
     ///
     /// - Parameter fhirId: The FHIR `id` of the resource that should be removed.
+    /// - returns: The removed ``FHIRResource``, if applicable.
     @MainActor
-    public func removeResource(withId fhirId: String) {
+    @discardableResult
+    public func removeResource(withId fhirId: String) -> FHIRResource? {
         guard let resource = _resources.first(where: { $0.fhirId == fhirId }) else {
-            return
+            return nil
         }
-        _$observationRegistrar.willSet(self, keyPath: resource.category.storeKeyPath)
-        _resources.removeAll { $0.fhirId == fhirId }
-        _$observationRegistrar.didSet(self, keyPath: resource.category.storeKeyPath)
+        return mutatingResourceCategories(CollectionOfOne(resource.category)) {
+            _resources.remove(resource)
+        }
     }
     
     /// Removes a FHIR resource from the ``FHIRStore``.
     ///
     /// - Parameter healthKitId: The HealthKit `uuid` of the resource that should be removed.
+    /// - returns: The removed ``FHIRResource``, if applicable.
     @_spi(Internal)
     @MainActor
-    public func removeResource(withHealthKitUUID healthKitId: String) {
+    @discardableResult
+    public func removeResource(withHealthKitUUID healthKitId: String) -> FHIRResource? {
         guard let resource = _resources.first(where: { $0.healthKitSampleId == healthKitId }) else {
+            return nil
+        }
+        return mutatingResourceCategories(CollectionOfOne(resource.category)) {
+            _resources.remove(resource)
+        }
+    }
+    
+    /// Removes all ``FHIRResource``s that satisfy the predicate.
+    @MainActor
+    public func removeAllResources(where predicate: (FHIRResource) throws -> Bool) rethrows {
+        let resourcesToRemove = try _resources.filter(predicate)
+        guard !resourcesToRemove.isEmpty else {
             return
         }
-        _$observationRegistrar.willSet(self, keyPath: resource.category.storeKeyPath)
-        _resources.removeAll { $0.healthKitSampleId == healthKitId }
-        _$observationRegistrar.didSet(self, keyPath: resource.category.storeKeyPath)
+        mutatingResourceCategories(resourcesToRemove.lazy.map(\.category)) {
+            _resources.subtract(resourcesToRemove)
+        }
     }
     
     /// Removes all resources from the ``FHIRStore``.
     @MainActor
     public func removeAllResources() {
-        for category in FHIRResource.FHIRResourceCategory.allCases {
-            _$observationRegistrar.willSet(self, keyPath: category.storeKeyPath)
-        }
-        _resources = []
-        for category in FHIRResource.FHIRResourceCategory.allCases {
-            _$observationRegistrar.didSet(self, keyPath: category.storeKeyPath)
-        }
+        removeAllResources { _ in true }
     }
 }
 
+
+// MARK: FHIRStore Helpers
+
+extension FHIRStore {
+    @MainActor
+    private func mutatingResourceCategories<Result>(
+        _ categories: some Sequence<FHIRResource.FHIRResourceCategory>,
+        _ operation: () -> Result
+    ) -> Result {
+        let categories = Array(Set(categories))
+        for category in categories {
+            _$observationRegistrar.willSet(self, keyPath: category.storeKeyPath)
+        }
+        let result = operation()
+        for category in categories.reversed() {
+            _$observationRegistrar.didSet(self, keyPath: category.storeKeyPath)
+        }
+        return result
+    }
+}
+
+
+// MARK: FHIRStore + Collection
 
 extension FHIRStore: @MainActor Collection {
     @MainActor public var isEmpty: Bool {
@@ -203,6 +230,13 @@ extension FHIRStore: @MainActor Collection {
     
     @MainActor public var endIndex: Set<FHIRResource>.Index {
         _resources.endIndex
+    }
+    
+    @MainActor
+    public func _customContainsEquatableElement( // swiftlint:disable:this identifier_name
+        _ element: FHIRResource
+    ) -> Bool? { // swiftlint:disable:this discouraged_optional_boolean
+        _resources.contains(element)
     }
     
     @MainActor

--- a/Sources/SpeziFHIR/FHIRStore.swift
+++ b/Sources/SpeziFHIR/FHIRStore.swift
@@ -26,20 +26,20 @@ public final class FHIRStore: Module, EnvironmentAccessible, DefaultInitializabl
     // resources of that category are modified.
     @ObservationIgnored @MainActor private var _resources: Set<FHIRResource> = []
     @ObservationIgnored @Dependency(HealthKit.self) package var healthKit
-
-
+    
+    
     /// `FHIRResource`s with category `allergyIntolerance`.
     @MainActor public var allergyIntolerances: Set<FHIRResource> {
         access(keyPath: \.allergyIntolerances)
         return _resources.filter { $0.category == .allergyIntolerance }
     }
-
+    
     /// `FHIRResource`s with category `condition`.
     @MainActor public var conditions: Set<FHIRResource> {
         access(keyPath: \.conditions)
         return _resources.filter { $0.category == .condition }
     }
-
+    
     /// `FHIRResource`s with category `diagnostic`.
     @MainActor public var diagnostics: Set<FHIRResource> {
         access(keyPath: \.diagnostics)
@@ -51,48 +51,48 @@ public final class FHIRStore: Module, EnvironmentAccessible, DefaultInitializabl
         access(keyPath: \.documents)
         return _resources.filter { $0.category == .document }
     }
-
+    
     /// `FHIRResource`s with category `encounter`.
     @MainActor public var encounters: Set<FHIRResource> {
         access(keyPath: \.encounters)
         return _resources.filter { $0.category == .encounter }
     }
-
+    
     /// `FHIRResource`s with category `immunization`
     @MainActor public var immunizations: Set<FHIRResource> {
         access(keyPath: \.immunizations)
         return _resources.filter { $0.category == .immunization }
     }
-
+    
     /// `FHIRResource`s with category `medication`.
     @MainActor public var medications: Set<FHIRResource> {
         access(keyPath: \.medications)
         return _resources.filter { $0.category == .medication }
     }
-
+    
     /// `FHIRResource`s with category `observation`.
     @MainActor public var observations: Set<FHIRResource> {
         access(keyPath: \.observations)
         return _resources.filter { $0.category == .observation }
     }
-
+    
     /// `FHIRResource`s with category `procedure`.
     @MainActor public var procedures: Set<FHIRResource> {
         access(keyPath: \.procedures)
         return _resources.filter { $0.category == .procedure }
     }
-
+    
     /// `FHIRResource`s with category `other`.
     @MainActor public var otherResources: Set<FHIRResource> {
         access(keyPath: \.otherResources)
         return _resources.filter { $0.category == .other }
     }
-
-
+    
+    
     /// Create an empty ``FHIRStore``.
     public required init() {}
-
-
+    
+    
     /// Inserts a FHIR resource into the ``FHIRStore``.
     ///
     /// - Parameter resource: The `FHIRResource` to be inserted.
@@ -107,7 +107,7 @@ public final class FHIRStore: Module, EnvironmentAccessible, DefaultInitializabl
         _$observationRegistrar.didSet(self, keyPath: resource.category.storeKeyPath)
         return true
     }
-
+    
     /// Inserts a ``Collection`` of FHIR resources into the ``FHIRStore``.
     ///
     /// - Parameter resources: The `FHIRResource`s to be inserted.
@@ -123,19 +123,19 @@ public final class FHIRStore: Module, EnvironmentAccessible, DefaultInitializabl
             _$observationRegistrar.didSet(self, keyPath: category.storeKeyPath)
         }
     }
-
+    
     /// Loads resources from a given FHIR `Bundle` into the ``FHIRStore``.
     ///
     /// - Parameter bundle: The FHIR `Bundle` containing resources to be loaded.
     public func load(bundle: sending Bundle) async {
         let resourceProxies = bundle.entry?.compactMap { $0.resource } ?? []
         var resources: [FHIRResource] = []
-
+        
         for resourceProxy in resourceProxies {
             if Task.isCancelled {
                 return
             }
-
+            
             resources.append(
                 FHIRResource(
                     resource: resourceProxy.get(),
@@ -143,14 +143,14 @@ public final class FHIRStore: Module, EnvironmentAccessible, DefaultInitializabl
                 )
             )
         }
-
+        
         if Task.isCancelled {
             return
         }
-
+        
         await insert(resources: resources)
     }
-
+    
     /// Removes a FHIR resource from the ``FHIRStore``.
     ///
     /// - Parameter fhirId: The FHIR `id` of the resource that should be removed.
@@ -177,7 +177,7 @@ public final class FHIRStore: Module, EnvironmentAccessible, DefaultInitializabl
         _resources.removeAll { $0.healthKitSampleId == healthKitId }
         _$observationRegistrar.didSet(self, keyPath: resource.category.storeKeyPath)
     }
-
+    
     /// Removes all resources from the ``FHIRStore``.
     @MainActor
     public func removeAllResources() {
@@ -188,6 +188,13 @@ public final class FHIRStore: Module, EnvironmentAccessible, DefaultInitializabl
         for category in FHIRResource.FHIRResourceCategory.allCases {
             _$observationRegistrar.didSet(self, keyPath: category.storeKeyPath)
         }
+    }
+}
+
+
+extension FHIRStore {
+    @MainActor public var isEmpty: Bool {
+        _resources.isEmpty
     }
 }
 

--- a/Sources/SpeziFHIR/FHIRStore.swift
+++ b/Sources/SpeziFHIR/FHIRStore.swift
@@ -131,11 +131,12 @@ extension FHIRStore {
     /// Loads resources from a given FHIR `Bundle` into the ``FHIRStore``.
     ///
     /// - Parameter bundle: The FHIR `Bundle` containing resources to be loaded.
-    public func load(bundle: sending Bundle) async {
+    @MainActor
+    public func load(bundle: sending Bundle) {
         guard let resourceProxies = bundle.entry?.compactMap(\.resource), !resourceProxies.isEmpty else {
             return
         }
-        await insert(contentsOf: resourceProxies.lazy.map {
+        insert(contentsOf: resourceProxies.lazy.map {
             FHIRResource(resource: $0.get(), displayName: $0.displayName)
         })
     }

--- a/Sources/SpeziFHIR/FHIRStore.swift
+++ b/Sources/SpeziFHIR/FHIRStore.swift
@@ -192,9 +192,27 @@ public final class FHIRStore: Module, EnvironmentAccessible, DefaultInitializabl
 }
 
 
-extension FHIRStore {
+extension FHIRStore: @MainActor Collection {
     @MainActor public var isEmpty: Bool {
         _resources.isEmpty
+    }
+    
+    @MainActor public var startIndex: Set<FHIRResource>.Index {
+        _resources.startIndex
+    }
+    
+    @MainActor public var endIndex: Set<FHIRResource>.Index {
+        _resources.endIndex
+    }
+    
+    @MainActor
+    public func index(after idx: Set<FHIRResource>.Index) -> Set<FHIRResource>.Index {
+        _resources.index(after: idx)
+    }
+    
+    @MainActor
+    public subscript(position: Set<FHIRResource>.Index) -> FHIRResource {
+        _resources[position]
     }
 }
 

--- a/Sources/SpeziFHIR/FHIRStore.swift
+++ b/Sources/SpeziFHIR/FHIRStore.swift
@@ -24,66 +24,66 @@ public final class FHIRStore: Module, EnvironmentAccessible, DefaultInitializabl
     // with specific keyPaths in the `insert`, `remove`, and other mutation methods. This ensures that
     // only observers of the relevant category (e.g., observations, conditions) are notified when
     // resources of that category are modified.
-    @ObservationIgnored @MainActor private var _resources: [FHIRResource] = []
+    @ObservationIgnored @MainActor private var _resources: Set<FHIRResource> = []
     @ObservationIgnored @Dependency(HealthKit.self) package var healthKit
 
 
     /// `FHIRResource`s with category `allergyIntolerance`.
-    @MainActor public var allergyIntolerances: [FHIRResource] {
+    @MainActor public var allergyIntolerances: Set<FHIRResource> {
         access(keyPath: \.allergyIntolerances)
         return _resources.filter { $0.category == .allergyIntolerance }
     }
 
     /// `FHIRResource`s with category `condition`.
-    @MainActor public var conditions: [FHIRResource] {
+    @MainActor public var conditions: Set<FHIRResource> {
         access(keyPath: \.conditions)
         return _resources.filter { $0.category == .condition }
     }
 
     /// `FHIRResource`s with category `diagnostic`.
-    @MainActor public var diagnostics: [FHIRResource] {
+    @MainActor public var diagnostics: Set<FHIRResource> {
         access(keyPath: \.diagnostics)
         return _resources.filter { $0.category == .diagnostic }
     }
     
     /// `FHIRResource`s with category `documentReference`.
-    @MainActor public var documents: [FHIRResource] {
+    @MainActor public var documents: Set<FHIRResource> {
         access(keyPath: \.documents)
         return _resources.filter { $0.category == .document }
     }
 
     /// `FHIRResource`s with category `encounter`.
-    @MainActor public var encounters: [FHIRResource] {
+    @MainActor public var encounters: Set<FHIRResource> {
         access(keyPath: \.encounters)
         return _resources.filter { $0.category == .encounter }
     }
 
     /// `FHIRResource`s with category `immunization`
-    @MainActor public var immunizations: [FHIRResource] {
+    @MainActor public var immunizations: Set<FHIRResource> {
         access(keyPath: \.immunizations)
         return _resources.filter { $0.category == .immunization }
     }
 
     /// `FHIRResource`s with category `medication`.
-    @MainActor public var medications: [FHIRResource] {
+    @MainActor public var medications: Set<FHIRResource> {
         access(keyPath: \.medications)
         return _resources.filter { $0.category == .medication }
     }
 
     /// `FHIRResource`s with category `observation`.
-    @MainActor public var observations: [FHIRResource] {
+    @MainActor public var observations: Set<FHIRResource> {
         access(keyPath: \.observations)
         return _resources.filter { $0.category == .observation }
     }
 
     /// `FHIRResource`s with category `procedure`.
-    @MainActor public var procedures: [FHIRResource] {
+    @MainActor public var procedures: Set<FHIRResource> {
         access(keyPath: \.procedures)
         return _resources.filter { $0.category == .procedure }
     }
 
     /// `FHIRResource`s with category `other`.
-    @MainActor public var otherResources: [FHIRResource] {
+    @MainActor public var otherResources: Set<FHIRResource> {
         access(keyPath: \.otherResources)
         return _resources.filter { $0.category == .other }
     }
@@ -97,23 +97,29 @@ public final class FHIRStore: Module, EnvironmentAccessible, DefaultInitializabl
     ///
     /// - Parameter resource: The `FHIRResource` to be inserted.
     @MainActor
-    public func insert(resource: FHIRResource) {
+    @discardableResult
+    public func insert(resource: FHIRResource) -> Bool {
+        guard !_resources.contains(resource) else {
+            return false
+        }
         _$observationRegistrar.willSet(self, keyPath: resource.category.storeKeyPath)
-        _resources.append(resource)
+        _resources.insert(resource)
         _$observationRegistrar.didSet(self, keyPath: resource.category.storeKeyPath)
+        return true
     }
 
     /// Inserts a ``Collection`` of FHIR resources into the ``FHIRStore``.
     ///
     /// - Parameter resources: The `FHIRResource`s to be inserted.
     @MainActor
-    public func insert<T: Collection>(resources: T) where T.Element == FHIRResource {
-        let resourceCategories = Set(resources.map(\.category))
+    public func insert(resources: some Collection<FHIRResource>) {
+        let resources = resources.filter { !_resources.contains($0) }
+        let resourceCategories = Array(resources.mapIntoSet(\.category))
         for category in resourceCategories {
             _$observationRegistrar.willSet(self, keyPath: category.storeKeyPath)
         }
-        self._resources.append(contentsOf: resources)
-        for category in resourceCategories {
+        _resources.formUnion(resources)
+        for category in resourceCategories.reversed() {
             _$observationRegistrar.didSet(self, keyPath: category.storeKeyPath)
         }
     }
@@ -181,6 +187,15 @@ public final class FHIRStore: Module, EnvironmentAccessible, DefaultInitializabl
         _resources = []
         for category in FHIRResource.FHIRResourceCategory.allCases {
             _$observationRegistrar.didSet(self, keyPath: category.storeKeyPath)
+        }
+    }
+}
+
+
+extension Set {
+    fileprivate mutating func removeAll(where predicate: (Element) -> Bool) {
+        for element in self where predicate(element) {
+            remove(element)
         }
     }
 }

--- a/Sources/SpeziFHIRHealthKit/FHIRStore+HealthKit.swift
+++ b/Sources/SpeziFHIRHealthKit/FHIRStore+HealthKit.swift
@@ -27,12 +27,13 @@ extension FHIRStore {
         if loadHealthKitAttachments {
             try await resource.loadAttachments(for: sample, using: healthKit)
         }
-        await insert(resource: resource)
+        await insert(resource)
     }
     
     /// Remove a HealthKit sample delete object from the FHIR store.
     /// - Parameter sample: The sample delete object that should be removed.
-    public func remove(_ deletedObject: HKDeletedObject) async {
-        await removeResource(withHealthKitUUID: deletedObject.uuid.uuidString)
+    @MainActor
+    public func remove(_ deletedObject: HKDeletedObject) {
+        removeResource(withHealthKitUUID: deletedObject.uuid.uuidString)
     }
 }

--- a/Sources/SpeziFHIRMockPatients/FHIRBundleSelector.swift
+++ b/Sources/SpeziFHIRMockPatients/FHIRBundleSelector.swift
@@ -24,10 +24,7 @@ public struct FHIRBundleSelector: View {
 
     @Environment(FHIRStore.self) private var store
     @State private var selectedBundleId: PatientIdentifiedBundle.ID?
-    @State private var fhirResourceLoadingTask: Task<Void, Never>?
-
     private let bundles: [PatientIdentifiedBundle]
-
 
     public var body: some View {
         Picker(
@@ -63,19 +60,12 @@ public struct FHIRBundleSelector: View {
             }
             // Remove existing resources and load the newly selected bundle
             .onChange(of: selectedBundleId) { _, newValue in
-                fhirResourceLoadingTask?.cancel()
-                fhirResourceLoadingTask = nil
-
                 guard let newValue,
                       let selected = bundles.first(where: { $0.id == newValue }) else {
                     return
                 }
-
                 store.removeAllResources()
-
-                fhirResourceLoadingTask = Task {
-                    await store.load(bundle: selected.bundle)
-                }
+                store.load(bundle: selected.bundle)
             }
     }
     
@@ -85,7 +75,6 @@ public struct FHIRBundleSelector: View {
             guard let id = $0.patient?.identifier?.first?.value?.value?.string else {
                 return nil
             }
-            
             return PatientIdentifiedBundle(id: id, bundle: $0)
         }
     }

--- a/Sources/SpeziFHIRMockPatients/FHIRStore+TestingSupport.swift
+++ b/Sources/SpeziFHIRMockPatients/FHIRStore+TestingSupport.swift
@@ -12,20 +12,19 @@ import SpeziFHIR
 
 extension FHIRStore {
     /// Loads a mock resource into the `FHIRStore` for testing purposes.
+    @MainActor
     public func loadTestingResources() async {
+        removeAllResources()
+        
         let mockObservation = Observation(
             code: CodeableConcept(coding: [Coding(code: "1234".asFHIRStringPrimitive())]),
             id: FHIRPrimitive<FHIRString>("1234"),
             issued: FHIRPrimitive<Instant>(try? Instant(date: .now)),
             status: FHIRPrimitive(ObservationStatus.final)
         )
-        
-        let mockFHIRResource = FHIRResource(
+        insert(FHIRResource(
             versionedResource: .r4(mockObservation),
             displayName: "Mock Resource"
-        )
-        
-        await removeAllResources()
-        await insert(resource: mockFHIRResource)
+        ))
     }
 }

--- a/Tests/SpeziFHIRTests/FHIRResource/FHIRResourceSearchTests.swift
+++ b/Tests/SpeziFHIRTests/FHIRResource/FHIRResourceSearchTests.swift
@@ -38,19 +38,16 @@ extension FHIRResourceTests {
             versionedResource: .r4(observation),
             displayName: "Test Resource1"
         )
-        
         let resource2 = FHIRResource(
             versionedResource: .r4(patient),
             displayName: "Test Resource2"
         )
-        
         let resource3 = FHIRResource(
             versionedResource: .r4(medicationRequest),
             displayName: "Test Resource3"
         )
         
-        let resources = [resource1, resource2, resource3]
-        
+        let resources: Set = [resource1, resource2, resource3]
         #expect(resources.filterByDisplayName(with: "test").count == 3)
         #expect(resources.filterByDisplayName(with: "resource1").count == 1)
         #expect(resources.filterByDisplayName(with: "xyz").isEmpty)

--- a/Tests/SpeziFHIRTests/FHIRStore/FHIRStoreObservationChangesTests.swift
+++ b/Tests/SpeziFHIRTests/FHIRStore/FHIRStoreObservationChangesTests.swift
@@ -31,7 +31,7 @@ struct FHIRStoreObservationChangesTests {
                 observationsExpectation()
             }
             
-            store.insert(resource: resource)
+            store.insert(resource)
             
             #expect(store.procedures.isEmpty)
             #expect(store.observations.count == 1)
@@ -73,7 +73,7 @@ struct FHIRStoreObservationChangesTests {
                 changeExpectation()
             }
             
-            store.insert(resources: [observationResource, medicationResource])
+            store.insert(contentsOf: [observationResource, medicationResource])
             
             #expect(store.procedures.isEmpty)
             #expect(store.observations.count == 1)
@@ -86,7 +86,7 @@ struct FHIRStoreObservationChangesTests {
         let observation = try ModelsR4Mocks.createObservation()
         let resource = FHIRResource(resource: observation, displayName: "Test Observation")
         
-        store.insert(resource: resource)
+        store.insert(resource)
         
         await confirmation { observationsExpectation in
             withObservationTracking {
@@ -133,7 +133,7 @@ struct FHIRStoreObservationChangesTests {
         let other = try ModelsR4Mocks.createProvenance()
         let otherResource = FHIRResource(resource: other, displayName: "Test Other")
         
-        store.insert(resources: [
+        store.insert(contentsOf: [
             allergyIntoleranceResource,
             conditionResource,
             diagnosticResource,

--- a/Tests/SpeziFHIRTests/FHIRStore/FHIRStoreTests.swift
+++ b/Tests/SpeziFHIRTests/FHIRStore/FHIRStoreTests.swift
@@ -173,6 +173,7 @@ struct FHIRStoreTests {
         let bundle = try ModelsR4Mocks.createBundle()
         let condition1 = try ModelsR4Mocks.createCondition()
         let condition2 = try ModelsR4Mocks.createCondition()
+        #expect(store.isEmpty)
         
         bundle.entry = [
             BundleEntry(resource: .condition(condition1)),
@@ -180,9 +181,7 @@ struct FHIRStoreTests {
         ]
         
         await store.load(bundle: bundle)
-        
-        #expect(store.conditions.count == 2)
-        #expect(store.conditions[0].id.fhirResourceId == "condition-id")
-        #expect(store.conditions[1].id.fhirResourceId == "condition-id")
+        #expect(store.conditions.count == 1)
+        #expect(try #require(store.conditions.first).id.fhirResourceId == "condition-id")
     }
 }

--- a/Tests/SpeziFHIRTests/FHIRStore/FHIRStoreTests.swift
+++ b/Tests/SpeziFHIRTests/FHIRStore/FHIRStoreTests.swift
@@ -14,29 +14,27 @@ import Testing
 @Suite
 @MainActor
 struct FHIRStoreTests {
-    private var store = FHIRStore()
+    private let store = FHIRStore()
     
 
     @Test
-    func testInitialState() async {
-        await MainActor.run {
-            #expect(store.allergyIntolerances.isEmpty)
-            #expect(store.conditions.isEmpty)
-            #expect(store.diagnostics.isEmpty)
-            #expect(store.encounters.isEmpty)
-            #expect(store.immunizations.isEmpty)
-            #expect(store.medications.isEmpty)
-            #expect(store.observations.isEmpty)
-            #expect(store.procedures.isEmpty)
-            #expect(store.otherResources.isEmpty)
-        }
+    func testInitialState() {
+        #expect(store.allergyIntolerances.isEmpty)
+        #expect(store.conditions.isEmpty)
+        #expect(store.diagnostics.isEmpty)
+        #expect(store.encounters.isEmpty)
+        #expect(store.immunizations.isEmpty)
+        #expect(store.medications.isEmpty)
+        #expect(store.observations.isEmpty)
+        #expect(store.procedures.isEmpty)
+        #expect(store.otherResources.isEmpty)
     }
 
     @Test
     func testInsertSingleResource() throws {
         let observation = try ModelsR4Mocks.createObservation()
         let resource = FHIRResource(resource: observation, displayName: "Test Observation")
-        store.insert(resource: resource)
+        store.insert(resource)
 
         #expect(store.observations.count == 1)
         #expect(store.observations.first?.displayName == "Test Observation")
@@ -59,7 +57,7 @@ struct FHIRStoreTests {
             FHIRResource(resource: claim, displayName: "Claim")
         ]
 
-        store.insert(resources: resources)
+        store.insert(contentsOf: resources)
         
         #expect(store.observations.count == 2)
         #expect(store.procedures.count == 1)
@@ -72,7 +70,7 @@ struct FHIRStoreTests {
         let medication = ModelsR4Mocks.createMedication()
         let resource = FHIRResource(resource: medication, displayName: "Medication")
             
-        store.insert(resource: resource)
+        store.insert(resource)
         #expect(store.medications.count == 1)
         
         store.removeResource(withId: resource.id.fhirResourceId)
@@ -93,7 +91,7 @@ struct FHIRStoreTests {
             FHIRResource(resource: medication, displayName: "Medication")
         ]
         
-        store.insert(resources: resources)
+        store.insert(contentsOf: resources)
         store.removeAllResources()
 
         #expect(store.observations.isEmpty)
@@ -102,11 +100,9 @@ struct FHIRStoreTests {
     }
 
     @Test
-    func testLoadEmptyBundle() async {
+    func testLoadEmptyBundle() {
         let bundle = ModelsR4.Bundle(type: FHIRPrimitive<BundleType>(.transaction))
-
-        await store.load(bundle: bundle)
-
+        store.load(bundle: bundle)
         #expect(store.allergyIntolerances.isEmpty)
         #expect(store.conditions.isEmpty)
         #expect(store.observations.isEmpty)
@@ -119,9 +115,8 @@ struct FHIRStoreTests {
     }
 
     @Test
-    func testLoadBundleWithMultipleResources() async throws {
-        await store.load(bundle: try ModelsR4Mocks.createBundle())
-        
+    func testLoadBundleWithMultipleResources() throws {
+        store.load(bundle: try ModelsR4Mocks.createBundle())
         #expect(store.conditions.count == 1)
         #expect(store.observations.count == 1)
         #expect(store.conditions.first?.fhirId == "condition-id")
@@ -129,58 +124,34 @@ struct FHIRStoreTests {
     }
 
     @Test
-    func testLoadBundleCancellation() async throws {
-        let bundle = try ModelsR4Mocks.createBundle()
-            
-        var entries: [BundleEntry] = []
-        for _ in 0..<100 {
-            let condition = try ModelsR4Mocks.createCondition()
-            entries.append(BundleEntry(resource: .condition(condition)))
-        }
-        bundle.entry = entries
-
-        let task = _Concurrency.Task {
-            await store.load(bundle: bundle)
-        }
-
-        task.cancel()
-
-        await MainActor.run {
-            #expect(store.conditions.isEmpty)
-        }
-    }
-
-    @Test
-    func testLoadBundleWithInvalidResources() async throws {
+    func testLoadBundleWithInvalidResources() throws {
         let bundle = try ModelsR4Mocks.createBundle()
         let condition = try ModelsR4Mocks.createCondition()
         let emptyEntry = BundleEntry()
-        
         bundle.entry = [
             emptyEntry,
             BundleEntry(resource: .condition(condition))
         ]
         
-        await store.load(bundle: bundle)
-        
+        store.load(bundle: bundle)
         #expect(store.conditions.count == 1)
         #expect(store.conditions.first?.id.fhirResourceId == "condition-id")
         #expect(store.otherResources.isEmpty)
     }
 
     @Test
-    func testLoadBundleWithDuplicateResources() async throws {
+    func testLoadBundleWithDuplicateResources() throws {
+        #expect(store.isEmpty)
+        
         let bundle = try ModelsR4Mocks.createBundle()
         let condition1 = try ModelsR4Mocks.createCondition()
         let condition2 = try ModelsR4Mocks.createCondition()
-        #expect(store.isEmpty)
-        
         bundle.entry = [
             BundleEntry(resource: .condition(condition1)),
             BundleEntry(resource: .condition(condition2))
         ]
         
-        await store.load(bundle: bundle)
+        store.load(bundle: bundle)
         #expect(store.conditions.count == 1)
         #expect(try #require(store.conditions.first).id.fhirResourceId == "condition-id")
     }

--- a/Tests/UITests/TestApp/ContentView.swift
+++ b/Tests/UITests/TestApp/ContentView.swift
@@ -27,49 +27,50 @@ struct ContentView: View {
         NavigationStack {   // swiftlint:disable:this closure_body_length
             List {
                 Section {
-                    Text("Allergy Intolerances: \(fhirStore.allergyIntolerances.count)")
-                    Text("Conditions: \(fhirStore.conditions.count)")
-                    Text("Diagnostics: \(fhirStore.diagnostics.count)")
-                    Text("Documents: \(fhirStore.documents.count)")
-                    Text("Encounters: \(fhirStore.encounters.count)")
-                    Text("Immunizations: \(fhirStore.immunizations.count)")
-                    Text("Medications: \(fhirStore.medications.count)")
-                    Text("Observations: \(fhirStore.observations.count)")
-                    Text("Procedures: \(fhirStore.procedures.count)")
-                    Text("Other Resources: \(fhirStore.otherResources.count)")
+                    numResourcesRow("Allergy Intolerances", \.allergyIntolerances)
+                    numResourcesRow("Conditions", \.conditions)
+                    numResourcesRow("Diagnostics", \.diagnostics)
+                    numResourcesRow("Documents", \.documents)
+                    numResourcesRow("Encounters", \.encounters)
+                    numResourcesRow("Immunizations", \.immunizations)
+                    numResourcesRow("Medications", \.medications)
+                    numResourcesRow("Observations", \.observations)
+                    numResourcesRow("Procedures", \.procedures)
+                    numResourcesRow("Other Resources", \.otherResources)
                 }
                 Section {
                     presentPatientSelectionButton
                     collectFromHealthKitButton
                 }
             }
-                .viewStateAlert(state: $viewState)
-                .sheet(isPresented: $presentPatientSelection) {
-                    MockPatientSelection(presentPatientSelection: $presentPatientSelection)
-                }
-                .toolbar {
-                    ToolbarItem(placement: .navigationBarTrailing) {
-                        Button {
-                            fhirStore.insert(
-                                resource: .init(
-                                    resource: ModelsR4.Account(id: .init(stringLiteral: additionalFHIRResourceId), status: .init()),
-                                    displayName: "Random Account FHIR Resource"
-                                )
-                            )
-                        } label: {
-                            Label("Add", systemImage: "doc.badge.plus")
-                                .accessibilityLabel("Add FHIR Resource")
-                        }
-                    }
-                    ToolbarItem {
-                        Button {
-                            fhirStore.removeResource(withId: additionalFHIRResourceId)
-                        } label: {
-                            Label("Remove", systemImage: "folder.badge.minus")
-                                .accessibilityLabel("Remove FHIR Resource")
-                        }
+            .viewStateAlert(state: $viewState)
+            .sheet(isPresented: $presentPatientSelection) {
+                MockPatientSelection(presentPatientSelection: $presentPatientSelection)
+            }
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
+                        let resource = ModelsR4.Account(
+                            id: "\(additionalFHIRResourceId):\(UUID().uuidString)".asFHIRStringPrimitive(),
+                            status: .init()
+                        )
+                        fhirStore.insert(FHIRResource(resource: resource, displayName: "Random Account FHIR Resource"))
+                    } label: {
+                        Label("Add", systemImage: "doc.badge.plus")
+                            .accessibilityLabel("Add FHIR Resource")
                     }
                 }
+                ToolbarItem {
+                    Button {
+                        fhirStore.removeAllResources {
+                            ($0.fhirId ?? "").starts(with: additionalFHIRResourceId)
+                        }
+                    } label: {
+                        Label("Remove", systemImage: "folder.badge.minus")
+                            .accessibilityLabel("Remove FHIR Resource")
+                    }
+                }
+            }
         }
     }
     
@@ -89,5 +90,12 @@ struct ContentView: View {
             try await healthKit.askForAuthorization()
             await standard.fetchRecordsFromHealthKit()
         }
+    }
+    
+    private func numResourcesRow(
+        _ title: String,
+        _ resourcesKeyPath: KeyPath<FHIRStore, some Collection<FHIRResource>>
+    ) -> some View {
+        LabeledContent(title, value: fhirStore[keyPath: resourcesKeyPath].count, format: .number)
     }
 }

--- a/Tests/UITests/TestAppUITests/FHIRMockDataStorageProviderTests.swift
+++ b/Tests/UITests/TestAppUITests/FHIRMockDataStorageProviderTests.swift
@@ -14,16 +14,16 @@ final class SpeziFHIRTests: XCTestCase {
         let app = XCUIApplication()
         app.launch()
         
-        XCTAssert(app.staticTexts["Allergy Intolerances: 0"].waitForExistence(timeout: 2))
-        XCTAssert(app.staticTexts["Conditions: 0"].waitForExistence(timeout: 2))
-        XCTAssert(app.staticTexts["Diagnostics: 0"].waitForExistence(timeout: 2))
-        XCTAssert(app.staticTexts["Documents: 0"].waitForExistence(timeout: 2))
-        XCTAssert(app.staticTexts["Encounters: 0"].waitForExistence(timeout: 2))
-        XCTAssert(app.staticTexts["Immunizations: 0"].waitForExistence(timeout: 2))
-        XCTAssert(app.staticTexts["Medications: 0"].waitForExistence(timeout: 2))
-        XCTAssert(app.staticTexts["Observations: 0"].waitForExistence(timeout: 2))
-        XCTAssert(app.staticTexts["Procedures: 0"].waitForExistence(timeout: 2))
-        XCTAssert(app.staticTexts["Other Resources: 0"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Allergy Intolerances, 0"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Conditions, 0"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Diagnostics, 0"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Documents, 0"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Encounters, 0"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Immunizations, 0"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Medications, 0"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Observations, 0"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Procedures, 0"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Other Resources, 0"].waitForExistence(timeout: 2))
 
         XCTAssert(app.buttons["Select Mock Patient"].waitForExistence(timeout: 2))
         app.buttons["Select Mock Patient"].tap()
@@ -33,16 +33,16 @@ final class SpeziFHIRTests: XCTestCase {
         
         app.navigationBars["Select Mock Patient"].buttons["Close Mock Patient Selection"].tap()
         
-        XCTAssert(app.staticTexts["Allergy Intolerances: 0"].waitForExistence(timeout: 2))
-        XCTAssert(app.staticTexts["Conditions: 70"].waitForExistence(timeout: 2))
-        XCTAssert(app.staticTexts["Diagnostics: 205"].waitForExistence(timeout: 2))
-        XCTAssert(app.staticTexts["Documents: 82"].waitForExistence(timeout: 2))
-        XCTAssert(app.staticTexts["Encounters: 82"].waitForExistence(timeout: 2))
-        XCTAssert(app.staticTexts["Immunizations: 12"].waitForExistence(timeout: 2))
-        XCTAssert(app.staticTexts["Medications: 31"].waitForExistence(timeout: 2))
-        XCTAssert(app.staticTexts["Observations: 769"].waitForExistence(timeout: 2))
-        XCTAssert(app.staticTexts["Procedures: 106"].waitForExistence(timeout: 2))
-        XCTAssert(app.staticTexts["Other Resources: 220"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Allergy Intolerances, 0"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Conditions, 70"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Diagnostics, 205"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Documents, 82"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Encounters, 82"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Immunizations, 12"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Medications, 31"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Observations, 769"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Procedures, 106"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Other Resources, 220"].waitForExistence(timeout: 2))
 
         XCTAssert(app.buttons["Select Mock Patient"].waitForExistence(timeout: 2))
         app.buttons["Select Mock Patient"].tap()
@@ -52,26 +52,26 @@ final class SpeziFHIRTests: XCTestCase {
         
         app.navigationBars["Select Mock Patient"].buttons["Close Mock Patient Selection"].tap()
         
-        XCTAssert(app.staticTexts["Allergy Intolerances: 0"].waitForExistence(timeout: 2))
-        XCTAssert(app.staticTexts["Conditions: 37"].waitForExistence(timeout: 2))
-        XCTAssert(app.staticTexts["Diagnostics: 113"].waitForExistence(timeout: 2))
-        XCTAssert(app.staticTexts["Documents: 86"].waitForExistence(timeout: 2))
-        XCTAssert(app.staticTexts["Encounters: 86"].waitForExistence(timeout: 2))
-        XCTAssert(app.staticTexts["Immunizations: 11"].waitForExistence(timeout: 2))
-        XCTAssert(app.staticTexts["Medications: 55"].waitForExistence(timeout: 2))
-        XCTAssert(app.staticTexts["Observations: 169"].waitForExistence(timeout: 2))
-        XCTAssert(app.staticTexts["Procedures: 225"].waitForExistence(timeout: 2))
-        XCTAssert(app.staticTexts["Other Resources: 236"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Allergy Intolerances, 0"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Conditions, 37"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Diagnostics, 113"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Documents, 86"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Encounters, 86"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Immunizations, 11"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Medications, 55"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Observations, 169"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Procedures, 225"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Other Resources, 236"].waitForExistence(timeout: 2))
     }
-
+    
+    
     func testAddingAndRemovingResources() throws {
         let app = XCUIApplication()
         app.launch()
 
         // Add 5 resources
         for resourceCount in 0..<5 {
-            XCTAssert(app.staticTexts["Other Resources: \(resourceCount)"].waitForExistence(timeout: 2))
-
+            XCTAssert(app.staticTexts["Other Resources, \(resourceCount)"].waitForExistence(timeout: 2))
             XCTAssert(app.buttons["Add FHIR Resource"].waitForExistence(timeout: 2))
             app.buttons["Add FHIR Resource"].tap()
         }
@@ -80,13 +80,13 @@ final class SpeziFHIRTests: XCTestCase {
         XCTAssert(app.buttons["Remove FHIR Resource"].waitForExistence(timeout: 2))
         app.buttons["Remove FHIR Resource"].tap()
 
-        XCTAssert(app.staticTexts["Other Resources: 0"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Other Resources, 0"].waitForExistence(timeout: 2))
 
         // Try removing a second time
         XCTAssert(app.buttons["Remove FHIR Resource"].waitForExistence(timeout: 2))
         app.buttons["Remove FHIR Resource"].tap()
 
-        XCTAssert(app.staticTexts["Other Resources: 0"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Other Resources, 0"].waitForExistence(timeout: 2))
 
         // Select mock patient
         XCTAssert(app.buttons["Select Mock Patient"].waitForExistence(timeout: 2))
@@ -97,24 +97,24 @@ final class SpeziFHIRTests: XCTestCase {
 
         app.navigationBars["Select Mock Patient"].buttons["Close Mock Patient Selection"].tap()
 
-        XCTAssert(app.staticTexts["Other Resources: 220"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Other Resources, 220"].waitForExistence(timeout: 2))
 
         // Add resource to mock patient
         XCTAssert(app.buttons["Add FHIR Resource"].waitForExistence(timeout: 2))
         app.buttons["Add FHIR Resource"].tap()
 
-        XCTAssert(app.staticTexts["Other Resources: 221"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Other Resources, 221"].waitForExistence(timeout: 2))
 
         // Remove resource from mock patient
         XCTAssert(app.buttons["Remove FHIR Resource"].waitForExistence(timeout: 2))
         app.buttons["Remove FHIR Resource"].tap()
 
-        XCTAssert(app.staticTexts["Other Resources: 220"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Other Resources, 220"].waitForExistence(timeout: 2))
 
         // Try removing a second time
         XCTAssert(app.buttons["Remove FHIR Resource"].waitForExistence(timeout: 2))
         app.buttons["Remove FHIR Resource"].tap()
 
-        XCTAssert(app.staticTexts["Other Resources: 220"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["Other Resources, 220"].waitForExistence(timeout: 2))
     }
 }


### PR DESCRIPTION
# `FHIRStore`: handle duplicate entries

## :gear: Release Notes
- the `FHIRStore` now avoids inserting duplicate samples
- some types were changed from `[FHIRResource]` to `Set<FHIRResource>`
- added some additional operations to the `FHIRStore`

## :books: Documentation
n/a

## :white_check_mark: Testing
n/a

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
